### PR TITLE
fix: catch internal exceptions

### DIFF
--- a/src/Crash/CppException.cpp
+++ b/src/Crash/CppException.cpp
@@ -23,134 +23,144 @@ namespace Crash
 		// Try to demangle a C++ type name using UnDecorateSymbolName
 		std::string DemangleTypeName(const char* mangledName) noexcept
 		{
-			if (!mangledName || mangledName[0] == '\0') {
-				return "<unknown type>";
-			}
-
-			// UnDecorateSymbolName expects the name without the leading '.'
-			const char* nameStart = mangledName;
-			if (nameStart[0] == '.') {
-				++nameStart;
-			}
-
-			std::array<char, 1024> buffer{};
-			const auto result = UnDecorateSymbolName(
-				nameStart,
-				buffer.data(),
-				static_cast<DWORD>(buffer.size()),
-				UNDNAME_NAME_ONLY);  // Use UNDNAME_NAME_ONLY for cleaner output
-
-			if (result != 0) {
-				std::string demangled(buffer.data());
-
-				// Remove leading "class ", "struct ", etc. if present
-				const char* prefixes[] = { "class ", "struct ", "union ", "enum " };
-				for (const auto* prefix : prefixes) {
-					const size_t prefixLen = std::strlen(prefix);
-					if (demangled.compare(0, prefixLen, prefix) == 0) {
-						demangled = demangled.substr(prefixLen);
-						break;
-					}
+			try {
+				if (!mangledName || mangledName[0] == '\0') {
+					return "<unknown type>";
 				}
 
-				return demangled;
-			}
+				// UnDecorateSymbolName expects the name without the leading '.'
+				const char* nameStart = mangledName;
+				if (nameStart[0] == '.') {
+					++nameStart;
+				}
 
-			// Fallback to mangled name if undecorating fails
-			return std::string(mangledName);
+				std::array<char, 1024> buffer{};
+				const auto result = UnDecorateSymbolName(
+					nameStart,
+					buffer.data(),
+					static_cast<DWORD>(buffer.size()),
+					UNDNAME_NAME_ONLY);  // Use UNDNAME_NAME_ONLY for cleaner output
+
+				if (result != 0) {
+					std::string demangled(buffer.data());
+
+					// Remove leading "class ", "struct ", etc. if present
+					const char* prefixes[] = { "class ", "struct ", "union ", "enum " };
+					for (const auto* prefix : prefixes) {
+						const size_t prefixLen = std::strlen(prefix);
+						if (demangled.compare(0, prefixLen, prefix) == 0) {
+							demangled = demangled.substr(prefixLen);
+							break;
+						}
+					}
+
+					return demangled;
+				}
+
+				// Fallback to mangled name if undecorating fails
+				return std::string(mangledName);
+			} catch (...) {
+				// If any exception occurs (e.g., bad_alloc), return fallback
+				return "<demangle failed>";
+			}
 		}
 
 		// Extract type name from ThrowInfo structure
 		// Based on: https://devblogs.microsoft.com/oldnewthing/20100730-00/?p=13273
 		std::string ExtractTypeName(std::uintptr_t throwInfoAddress, std::uintptr_t moduleBase) noexcept
 		{
-			// ThrowInfo structure (x64, from ehdata.h):
-			// struct ThrowInfo {
-			//     DWORD attributes;
-			//     DWORD pmfnUnwind;     // RVA of destructor (or 0)
-			//     DWORD pForwardCompat; // RVA (unused)
-			//     DWORD pCatchableTypeArray; // RVA of CatchableTypeArray
-			// };
+			try {
+				// ThrowInfo structure (x64, from ehdata.h):
+				// struct ThrowInfo {
+				//     DWORD attributes;
+				//     DWORD pmfnUnwind;     // RVA of destructor (or 0)
+				//     DWORD pForwardCompat; // RVA (unused)
+				//     DWORD pCatchableTypeArray; // RVA of CatchableTypeArray
+				// };
 
-			std::uint32_t pCatchableTypeArrayRVA;
-			if (!SafeRead(throwInfoAddress + 12, pCatchableTypeArrayRVA)) {
-				return "<failed to read ThrowInfo>";
-			}
-
-			// Check for null RVA
-			if (pCatchableTypeArrayRVA == 0) {
-				return "<null CatchableTypeArray RVA>";
-			}
-
-			// Convert RVA to absolute address
-			const std::uintptr_t pCatchableTypeArray = moduleBase + pCatchableTypeArrayRVA;
-
-			// CatchableTypeArray structure:
-			// struct CatchableTypeArray {
-			//     int nCatchableTypes;
-			//     DWORD arrayOfCatchableTypes[]; // Array of RVAs
-			// };
-
-			int nCatchableTypes;
-			if (!SafeRead(pCatchableTypeArray, nCatchableTypes)) {
-				return "<failed to read CatchableTypeArray count>";
-			}
-
-			if (nCatchableTypes <= 0 || nCatchableTypes > 100) {
-				return "<invalid CatchableTypeArray count>";
-			}
-
-			// Read the first CatchableType RVA
-			std::uint32_t firstCatchableTypeRVA;
-			if (!SafeRead(pCatchableTypeArray + 4, firstCatchableTypeRVA)) {
-				return "<failed to read CatchableType RVA>";
-			}
-
-			if (firstCatchableTypeRVA == 0) {
-				return "<null CatchableType RVA>";
-			}
-
-			const std::uintptr_t pCatchableType = moduleBase + firstCatchableTypeRVA;
-
-			// CatchableType structure (x64):
-			// struct CatchableType {
-			//     DWORD properties;
-			//     DWORD pType; // RVA of type_info
-			//     ... more fields ...
-			// };
-
-			std::uint32_t typeInfoRVA;
-			if (!SafeRead(pCatchableType + 4, typeInfoRVA)) {
-				return "<failed to read type_info RVA>";
-			}
-
-			if (typeInfoRVA == 0) {
-				return "<null type_info RVA>";
-			}
-
-			const std::uintptr_t pTypeInfo = moduleBase + typeInfoRVA;
-
-			// type_info structure:
-			// class type_info {
-			//     void* pVFTable;
-			//     void* _M_spare;
-			//     char _M_name[]; // Decorated name starts here
-			// };
-
-			std::uintptr_t nameAddress = pTypeInfo + 16;  // Skip pVFTable (8) + _M_spare (8)
-
-			// Read the decorated name (null-terminated string)
-			std::array<char, 512> decoratedName{};
-			for (size_t i = 0; i < decoratedName.size() - 1; ++i) {
-				if (!SafeRead(nameAddress + i, decoratedName[i])) {
-					return "<failed to read type name>";
+				std::uint32_t pCatchableTypeArrayRVA;
+				if (!SafeRead(throwInfoAddress + 12, pCatchableTypeArrayRVA)) {
+					return "<failed to read ThrowInfo>";
 				}
-				if (decoratedName[i] == '\0') {
-					break;
-				}
-			}
 
-			return DemangleTypeName(decoratedName.data());
+				// Check for null RVA
+				if (pCatchableTypeArrayRVA == 0) {
+					return "<null CatchableTypeArray RVA>";
+				}
+
+				// Convert RVA to absolute address
+				const std::uintptr_t pCatchableTypeArray = moduleBase + pCatchableTypeArrayRVA;
+
+				// CatchableTypeArray structure:
+				// struct CatchableTypeArray {
+				//     int nCatchableTypes;
+				//     DWORD arrayOfCatchableTypes[]; // Array of RVAs
+				// };
+
+				int nCatchableTypes;
+				if (!SafeRead(pCatchableTypeArray, nCatchableTypes)) {
+					return "<failed to read CatchableTypeArray count>";
+				}
+
+				if (nCatchableTypes <= 0 || nCatchableTypes > 100) {
+					return "<invalid CatchableTypeArray count>";
+				}
+
+				// Read the first CatchableType RVA
+				std::uint32_t firstCatchableTypeRVA;
+				if (!SafeRead(pCatchableTypeArray + 4, firstCatchableTypeRVA)) {
+					return "<failed to read CatchableType RVA>";
+				}
+
+				if (firstCatchableTypeRVA == 0) {
+					return "<null CatchableType RVA>";
+				}
+
+				const std::uintptr_t pCatchableType = moduleBase + firstCatchableTypeRVA;
+
+				// CatchableType structure (x64):
+				// struct CatchableType {
+				//     DWORD properties;
+				//     DWORD pType; // RVA of type_info
+				//     ... more fields ...
+				// };
+
+				std::uint32_t typeInfoRVA;
+				if (!SafeRead(pCatchableType + 4, typeInfoRVA)) {
+					return "<failed to read type_info RVA>";
+				}
+
+				if (typeInfoRVA == 0) {
+					return "<null type_info RVA>";
+				}
+
+				const std::uintptr_t pTypeInfo = moduleBase + typeInfoRVA;
+
+				// type_info structure:
+				// class type_info {
+				//     void* pVFTable;
+				//     void* _M_spare;
+				//     char _M_name[]; // Decorated name starts here
+				// };
+
+				std::uintptr_t nameAddress = pTypeInfo + 16;  // Skip pVFTable (8) + _M_spare (8)
+
+				// Read the decorated name (null-terminated string)
+				std::array<char, 512> decoratedName{};
+				for (size_t i = 0; i < decoratedName.size() - 1; ++i) {
+					if (!SafeRead(nameAddress + i, decoratedName[i])) {
+						return "<failed to read type name>";
+					}
+					if (decoratedName[i] == '\0') {
+						break;
+					}
+				}
+
+				return DemangleTypeName(decoratedName.data());
+			} catch (...) {
+				// If any exception occurs (e.g., bad_alloc), return fallback
+				return "<type extraction failed>";
+			}
 		}
 	}
 
@@ -200,122 +210,127 @@ namespace Crash
 
 	std::optional<std::string> TryGetExceptionWhat(std::uintptr_t objectAddress) noexcept
 	{
-		// Attempt to treat the object as a std::exception-derived class
-		// This is dangerous and relies on the object being valid
+		try {
+			// Attempt to treat the object as a std::exception-derived class
+			// This is dangerous and relies on the object being valid
 
-		// Try reading as DX::com_exception (DirectXTK exception type)
-		// DX::com_exception layout varies but HRESULT is typically stored after the vtable and base class
-		// Try multiple common offsets: 8, 16, 24, 32 (covering various std::exception implementations)
-		const std::size_t hresultOffsets[] = { 8, 16, 24, 32 };
+			// Try reading as DX::com_exception (DirectXTK exception type)
+			// DX::com_exception layout varies but HRESULT is typically stored after the vtable and base class
+			// Try multiple common offsets: 8, 16, 24, 32 (covering various std::exception implementations)
+			const std::size_t hresultOffsets[] = { 8, 16, 24, 32 };
 
-		for (auto offset : hresultOffsets) {
-			std::int32_t hresult;
-			if (SafeRead(objectAddress + offset, hresult)) {
-				// Check if this looks like a valid HRESULT (high bit set for failures, common error codes)
-				// HRESULT format: S (1 bit) | R (2 bits) | C (1 bit) | N (1 bit) | X (11 bits) | Facility (11 bits) | Code (16 bits)
-				// Failure HRESULTs have the high bit set (0x80000000)
-				if ((hresult & 0x80000000) != 0) {
-					// Additional validation: check for common facility codes
-					// FACILITY_WIN32 (7), FACILITY_WINDOWS (8), FACILITY_ITF (4), etc.
-					const auto facility = (hresult >> 16) & 0x7FF;
-					if (facility <= 0x200) {  // Reasonable facility range
-						char hresultStr[128];
-						// Try to provide a friendly name for common HRESULT values
-						const char* friendlyName = "";
-						switch (static_cast<std::uint32_t>(hresult)) {
-						case 0x887A0005:
-							friendlyName = " (DXGI_ERROR_DEVICE_REMOVED)";
-							break;
-						case 0x887A0006:
-							friendlyName = " (DXGI_ERROR_DEVICE_HUNG)";
-							break;
-						case 0x887A0007:
-							friendlyName = " (DXGI_ERROR_DEVICE_RESET)";
-							break;
-						case 0x80070057:
-							friendlyName = " (E_INVALIDARG)";
-							break;
-						case 0x8007000E:
-							friendlyName = " (E_OUTOFMEMORY)";
-							break;
-						case 0x80004001:
-							friendlyName = " (E_NOTIMPL)";
-							break;
-						case 0x80004002:
-							friendlyName = " (E_NOINTERFACE)";
-							break;
-						case 0x80004003:
-							friendlyName = " (E_POINTER)";
-							break;
-						case 0x80004004:
-							friendlyName = " (E_ABORT)";
-							break;
-						case 0x80004005:
-							friendlyName = " (E_FAIL)";
-							break;
+			for (auto offset : hresultOffsets) {
+				std::int32_t hresult;
+				if (SafeRead(objectAddress + offset, hresult)) {
+					// Check if this looks like a valid HRESULT (high bit set for failures, common error codes)
+					// HRESULT format: S (1 bit) | R (2 bits) | C (1 bit) | N (1 bit) | X (11 bits) | Facility (11 bits) | Code (16 bits)
+					// Failure HRESULTs have the high bit set (0x80000000)
+					if ((hresult & 0x80000000) != 0) {
+						// Additional validation: check for common facility codes
+						// FACILITY_WIN32 (7), FACILITY_WINDOWS (8), FACILITY_ITF (4), etc.
+						const auto facility = (hresult >> 16) & 0x7FF;
+						if (facility <= 0x200) {  // Reasonable facility range
+							char hresultStr[128];
+							// Try to provide a friendly name for common HRESULT values
+							const char* friendlyName = "";
+							switch (static_cast<std::uint32_t>(hresult)) {
+							case 0x887A0005:
+								friendlyName = " (DXGI_ERROR_DEVICE_REMOVED)";
+								break;
+							case 0x887A0006:
+								friendlyName = " (DXGI_ERROR_DEVICE_HUNG)";
+								break;
+							case 0x887A0007:
+								friendlyName = " (DXGI_ERROR_DEVICE_RESET)";
+								break;
+							case 0x80070057:
+								friendlyName = " (E_INVALIDARG)";
+								break;
+							case 0x8007000E:
+								friendlyName = " (E_OUTOFMEMORY)";
+								break;
+							case 0x80004001:
+								friendlyName = " (E_NOTIMPL)";
+								break;
+							case 0x80004002:
+								friendlyName = " (E_NOINTERFACE)";
+								break;
+							case 0x80004003:
+								friendlyName = " (E_POINTER)";
+								break;
+							case 0x80004004:
+								friendlyName = " (E_ABORT)";
+								break;
+							case 0x80004005:
+								friendlyName = " (E_FAIL)";
+								break;
+							}
+							std::snprintf(hresultStr, sizeof(hresultStr), "HRESULT 0x%08X%s",
+								static_cast<std::uint32_t>(hresult), friendlyName);
+							return std::string(hresultStr);
 						}
-						std::snprintf(hresultStr, sizeof(hresultStr), "HRESULT 0x%08X%s",
-							static_cast<std::uint32_t>(hresult), friendlyName);
-						return std::string(hresultStr);
 					}
 				}
 			}
-		}
 
-		// std::exception layout (MSVC):
-		// - vtable pointer (8 bytes)
-		// - _Mywhat pointer (8 bytes) or inline storage
+			// std::exception layout (MSVC):
+			// - vtable pointer (8 bytes)
+			// - _Mywhat pointer (8 bytes) or inline storage
 
-		// Get the vtable pointer
-		std::uintptr_t vtablePtr;
-		if (!SafeRead(objectAddress, vtablePtr)) {
-			return std::nullopt;
-		}
-
-		// Get the what() function pointer from vtable
-		// The what() function is typically at offset 8 in the vtable (after destructor)
-		std::uintptr_t whatFuncPtr;
-		if (!SafeRead(vtablePtr + 8, whatFuncPtr)) {
-			return std::nullopt;
-		}
-
-		// We can't safely call what() directly because:
-		// 1. The object might not be a std::exception
-		// 2. Calling virtual functions from a crash handler is risky
-		// Instead, try to read the _Mywhat member directly
-
-		// For std::exception, the message is usually stored at offset 8 (after vtable)
-		std::uintptr_t messagePtr;
-		if (!SafeRead(objectAddress + 8, messagePtr)) {
-			return std::nullopt;
-		}
-
-		// Check if messagePtr looks valid (not null, in reasonable range)
-		if (messagePtr == 0 || messagePtr < 0x1000) {
-			return std::nullopt;
-		}
-
-		// Try to read the string (with a reasonable limit)
-		char messageBuffer[512];
-		std::memset(messageBuffer, 0, sizeof(messageBuffer));
-
-		for (size_t i = 0; i < sizeof(messageBuffer) - 1; ++i) {
-			if (!SafeRead(messagePtr + i, messageBuffer[i])) {
+			// Get the vtable pointer
+			std::uintptr_t vtablePtr;
+			if (!SafeRead(objectAddress, vtablePtr)) {
 				return std::nullopt;
 			}
-			if (messageBuffer[i] == '\0') {
-				break;
-			}
-			// Sanity check: only printable ASCII characters and common whitespace
-			if ((messageBuffer[i] < 0x20 && messageBuffer[i] != '\t' && messageBuffer[i] != '\n' && messageBuffer[i] != '\r') || messageBuffer[i] > 0x7E) {
+
+			// Get the what() function pointer from vtable
+			// The what() function is typically at offset 8 in the vtable (after destructor)
+			std::uintptr_t whatFuncPtr;
+			if (!SafeRead(vtablePtr + 8, whatFuncPtr)) {
 				return std::nullopt;
 			}
-		}
 
-		if (messageBuffer[0] != '\0') {
-			return std::string(messageBuffer);
-		}
+			// We can't safely call what() directly because:
+			// 1. The object might not be a std::exception
+			// 2. Calling virtual functions from a crash handler is risky
+			// Instead, try to read the _Mywhat member directly
 
-		return std::nullopt;
+			// For std::exception, the message is usually stored at offset 8 (after vtable)
+			std::uintptr_t messagePtr;
+			if (!SafeRead(objectAddress + 8, messagePtr)) {
+				return std::nullopt;
+			}
+
+			// Check if messagePtr looks valid (not null, in reasonable range)
+			if (messagePtr == 0 || messagePtr < 0x1000) {
+				return std::nullopt;
+			}
+
+			// Try to read the string (with a reasonable limit)
+			char messageBuffer[512];
+			std::memset(messageBuffer, 0, sizeof(messageBuffer));
+
+			for (size_t i = 0; i < sizeof(messageBuffer) - 1; ++i) {
+				if (!SafeRead(messagePtr + i, messageBuffer[i])) {
+					return std::nullopt;
+				}
+				if (messageBuffer[i] == '\0') {
+					break;
+				}
+				// Sanity check: only printable ASCII characters and common whitespace
+				if ((messageBuffer[i] < 0x20 && messageBuffer[i] != '\t' && messageBuffer[i] != '\n' && messageBuffer[i] != '\r') || messageBuffer[i] > 0x7E) {
+					return std::nullopt;
+				}
+			}
+
+			if (messageBuffer[0] != '\0') {
+				return std::string(messageBuffer);
+			}
+
+			return std::nullopt;
+		} catch (...) {
+			// If any exception occurs (e.g., bad_alloc), return nullopt
+			return std::nullopt;
+		}
 	}
 }

--- a/src/Crash/CrashHandler.cpp
+++ b/src/Crash/CrashHandler.cpp
@@ -1594,40 +1594,61 @@ next_label:;
 
 			} catch (const SEHException& se) {
 				// Log the SEH exception to the existing log (or create new if needed)
-				if (!log) {
-					auto [logPtr, logPath] = get_timestamped_log("crash-"sv, "crash log"s);
-					log = logPtr;
-					crashLogPath = logPath;
+				// Wrap in try-catch to prevent std::terminate from noexcept function
+				try {
+					if (!log) {
+						auto [logPtr, logPath] = get_timestamped_log("crash-"sv, "crash log"s);
+						log = logPtr;
+						crashLogPath = logPath;
+					}
+					log->critical("");
+					log->critical("===== CRASH LOGGER INTERNAL ERROR =====");
+					log->critical("SEH Exception occurred during crash log generation: {} (Code: 0x{:X})", se.what(), se.code());
+					log->critical("The crash log above may be incomplete.");
+					log->flush();
+				} catch (...) {
+					// Last resort: can't create logger or log failed, just terminate
+					TerminateProcess(GetCurrentProcess(), EXIT_FAILURE);
+					return EXCEPTION_CONTINUE_SEARCH;
 				}
-				log->critical("");
-				log->critical("===== CRASH LOGGER INTERNAL ERROR =====");
-				log->critical("SEH Exception occurred during crash log generation: {} (Code: 0x{:X})", se.what(), se.code());
-				log->critical("The crash log above may be incomplete.");
-				log->flush();
 			} catch (const std::exception& e) {
 				// Log the C++ exception to the existing log (or create new if needed)
-				if (!log) {
-					auto [logPtr, logPath] = get_timestamped_log("crash-"sv, "crash log"s);
-					log = logPtr;
-					crashLogPath = logPath;
+				// Wrap in try-catch to prevent std::terminate from noexcept function
+				try {
+					if (!log) {
+						auto [logPtr, logPath] = get_timestamped_log("crash-"sv, "crash log"s);
+						log = logPtr;
+						crashLogPath = logPath;
+					}
+					log->critical("");
+					log->critical("===== CRASH LOGGER INTERNAL ERROR =====");
+					log->critical("C++ exception occurred during crash log generation: {}", e.what());
+					log->critical("The crash log above may be incomplete.");
+					log->flush();
+				} catch (...) {
+					// Last resort: can't create logger or log failed, just terminate
+					TerminateProcess(GetCurrentProcess(), EXIT_FAILURE);
+					return EXCEPTION_CONTINUE_SEARCH;
 				}
-				log->critical("");
-				log->critical("===== CRASH LOGGER INTERNAL ERROR =====");
-				log->critical("C++ exception occurred during crash log generation: {}", e.what());
-				log->critical("The crash log above may be incomplete.");
-				log->flush();
 			} catch (...) {
 				// Catch any other unknown exception to the existing log (or create new if needed)
-				if (!log) {
-					auto [logPtr, logPath] = get_timestamped_log("crash-"sv, "crash log"s);
-					log = logPtr;
-					crashLogPath = logPath;
+				// Wrap in try-catch to prevent std::terminate from noexcept function
+				try {
+					if (!log) {
+						auto [logPtr, logPath] = get_timestamped_log("crash-"sv, "crash log"s);
+						log = logPtr;
+						crashLogPath = logPath;
+					}
+					log->critical("");
+					log->critical("===== CRASH LOGGER INTERNAL ERROR =====");
+					log->critical("Unknown exception occurred during crash log generation");
+					log->critical("The crash log above may be incomplete.");
+					log->flush();
+				} catch (...) {
+					// Last resort: can't create logger or log failed, just terminate
+					TerminateProcess(GetCurrentProcess(), EXIT_FAILURE);
+					return EXCEPTION_CONTINUE_SEARCH;
 				}
-				log->critical("");
-				log->critical("===== CRASH LOGGER INTERNAL ERROR =====");
-				log->critical("Unknown exception occurred during crash log generation");
-				log->critical("The crash log above may be incomplete.");
-				log->flush();
 			}
 
 			// Upload crash log to pastebin if enabled

--- a/src/Crash/CrashHandler.cpp
+++ b/src/Crash/CrashHandler.cpp
@@ -655,52 +655,80 @@ namespace Crash
 				a_log.critical("In-Page Error: Tried to {} memory at 0x{:012X}, NTSTATUS: 0x{:08X}"sv, accessType, faultAddress, ntStatus);
 			} else if (IsCppException(a_exception)) {
 				// Parse and display C++ exception details
-				if (const auto cppExInfo = ParseCppException(a_exception)) {
-					a_log.critical("");
-					a_log.critical("C++ EXCEPTION:");
+				// Wrap entire C++ exception parsing in try-catch to prevent secondary crashes
+				try {
+					if (const auto cppExInfo = ParseCppException(a_exception)) {
+						a_log.critical("");
+						a_log.critical("C++ EXCEPTION:");
 
-					// Use existing introspection system to analyze the exception object
-					const std::size_t addresses[] = { cppExInfo->objectAddress };
-					const auto analysis = Introspection::analyze_data(addresses, a_modules);
+						// Use existing introspection system to analyze the exception object
+						try {
+							const std::size_t addresses[] = { cppExInfo->objectAddress };
+							const auto analysis = Introspection::analyze_data(addresses, a_modules);
 
-					if (!analysis.empty() && !analysis[0].empty()) {
-						// The introspection system provides full type information with details
-						a_log.critical("\tType: {}"sv, analysis[0]);
+							if (!analysis.empty() && !analysis[0].empty()) {
+								// The introspection system provides full type information with details
+								a_log.critical("\tType: {}"sv, analysis[0]);
+							} else {
+								// Fallback to our manual parsing if introspection fails
+								a_log.critical("\tType: {}"sv, cppExInfo->typeName);
+							}
+						} catch (...) {
+							// If introspection fails, use fallback type name
+							a_log.critical("\tType: {}"sv, cppExInfo->typeName);
+						}
+
+						// Always try to extract additional info from the exception object (e.g., HRESULT)
+						try {
+							if (cppExInfo->what) {
+								a_log.critical("\tInfo: {}"sv, *cppExInfo->what);
+							}
+						} catch (...) {
+							a_log.critical("\tInfo: <failed to extract>"sv);
+						}
+
+						// Show the throw location if available (extracted from callstack)
+						try {
+							if (!a_throwLocation.empty()) {
+								a_log.critical("\tThrow Location: {}"sv, a_throwLocation);
+							}
+						} catch (...) {
+							a_log.critical("\tThrow Location: <failed to format>"sv);
+						}
+
+						// Log module information
+						try {
+							const auto modulePtr = reinterpret_cast<const void*>(cppExInfo->moduleBase);
+							const auto mod = Introspection::get_module_for_pointer(modulePtr, a_modules);
+							if (mod) {
+								a_log.critical("\tModule: {}"sv, mod->name());
+							}
+						} catch (...) {
+							a_log.critical("\tModule: <failed to determine>"sv);
+						}
 					} else {
-						// Fallback to our manual parsing if introspection fails
-						a_log.critical("\tType: {}"sv, cppExInfo->typeName);
+						a_log.critical("C++ Exception: Failed to parse exception details");
 					}
-
-					// Always try to extract additional info from the exception object (e.g., HRESULT)
-					if (cppExInfo->what) {
-						a_log.critical("\tInfo: {}"sv, *cppExInfo->what);
-					}
-
-					// Show the throw location if available (extracted from callstack)
-					if (!a_throwLocation.empty()) {
-						a_log.critical("\tThrow Location: {}"sv, a_throwLocation);
-					}
-
-					// Log module information
-					const auto modulePtr = reinterpret_cast<const void*>(cppExInfo->moduleBase);
-					const auto mod = Introspection::get_module_for_pointer(modulePtr, a_modules);
-					if (mod) {
-						a_log.critical("\tModule: {}"sv, mod->name());
-					}
-				} else {
-					a_log.critical("C++ Exception: Failed to parse exception details");
+				} catch (const std::exception& e) {
+					a_log.critical("C++ Exception: Fatal error during parsing - {}"sv, e.what());
+				} catch (...) {
+					a_log.critical("C++ Exception: Fatal error during parsing (unknown exception)"sv);
 				}
 			} else if (a_exception.NumberParameters > 0) {
 				a_log.critical("Exception Information Parameters:");
 				for (std::size_t i = 0; i < a_exception.NumberParameters; ++i) {
-					const auto param = a_exception.ExceptionInformation[i];
-					const std::size_t params[] = { param };
-					const auto analysis = Introspection::analyze_data(params, a_modules);
+					try {
+						const auto param = a_exception.ExceptionInformation[i];
+						const std::size_t params[] = { param };
+						const auto analysis = Introspection::analyze_data(params, a_modules);
 
-					if (!analysis.empty() && !analysis[0].empty()) {
-						a_log.critical("\tParameter[{}]: 0x{:012X} {}"sv, i, param, analysis[0]);
-					} else {
-						a_log.critical("\tParameter[{}]: 0x{:012X}"sv, i, param);
+						if (!analysis.empty() && !analysis[0].empty()) {
+							a_log.critical("\tParameter[{}]: 0x{:012X} {}"sv, i, param, analysis[0]);
+						} else {
+							a_log.critical("\tParameter[{}]: 0x{:012X}"sv, i, param);
+						}
+					} catch (...) {
+						a_log.critical("\tParameter[{}]: <failed to analyze>"sv, i);
 					}
 				}
 			}
@@ -1343,6 +1371,7 @@ next_label:;
 			_set_se_translator(seh_translator);
 
 			std::filesystem::path crashLogPath;
+			std::shared_ptr<spdlog::logger> log;
 
 			try {
 				const auto& debugConfig = Settings::GetSingleton()->GetDebug();
@@ -1357,7 +1386,8 @@ next_label:;
 
 				const auto modules = Modules::get_loaded_modules();
 				const std::span cmodules{ modules.begin(), modules.end() };
-				auto [log, logPath] = get_timestamped_log("crash-"sv, "crash log"s);
+				auto [logPtr, logPath] = get_timestamped_log("crash-"sv, "crash log"s);
+				log = logPtr;
 				crashLogPath = logPath;
 
 				// Clean up old logs
@@ -1563,19 +1593,40 @@ next_label:;
 				log->flush();
 
 			} catch (const SEHException& se) {
-				// Log the SEH exception converted to a C++ exception
-				auto [log, logPath] = get_timestamped_log("crash-"sv, "crash log"s);
-				log->critical("SEH Exception caught: {} (Code: 0x{:X})", se.what(), se.code());
+				// Log the SEH exception to the existing log (or create new if needed)
+				if (!log) {
+					auto [logPtr, logPath] = get_timestamped_log("crash-"sv, "crash log"s);
+					log = logPtr;
+					crashLogPath = logPath;
+				}
+				log->critical("");
+				log->critical("===== CRASH LOGGER INTERNAL ERROR =====");
+				log->critical("SEH Exception occurred during crash log generation: {} (Code: 0x{:X})", se.what(), se.code());
+				log->critical("The crash log above may be incomplete.");
 				log->flush();
 			} catch (const std::exception& e) {
-				// Log the C++ exception
-				auto [log, logPath] = get_timestamped_log("crash-"sv, "crash log"s);
-				log->critical("Caught C++ exception: {}", e.what());
+				// Log the C++ exception to the existing log (or create new if needed)
+				if (!log) {
+					auto [logPtr, logPath] = get_timestamped_log("crash-"sv, "crash log"s);
+					log = logPtr;
+					crashLogPath = logPath;
+				}
+				log->critical("");
+				log->critical("===== CRASH LOGGER INTERNAL ERROR =====");
+				log->critical("C++ exception occurred during crash log generation: {}", e.what());
+				log->critical("The crash log above may be incomplete.");
 				log->flush();
 			} catch (...) {
-				// Catch any other unknown exception
-				auto [log, logPath] = get_timestamped_log("crash-"sv, "crash log"s);
-				log->critical("Caught an unknown exception");
+				// Catch any other unknown exception to the existing log (or create new if needed)
+				if (!log) {
+					auto [logPtr, logPath] = get_timestamped_log("crash-"sv, "crash log"s);
+					log = logPtr;
+					crashLogPath = logPath;
+				}
+				log->critical("");
+				log->critical("===== CRASH LOGGER INTERNAL ERROR =====");
+				log->critical("Unknown exception occurred during crash log generation");
+				log->critical("The crash log above may be incomplete.");
 				log->flush();
 			}
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved crash-reporting robustness: logging now survives internal errors during exception analysis and data extraction, preventing secondary failures while producing coherent crash logs.
  * Added safer fallback reporting so missing or unreadable exception details yield explicit fallback messages instead of aborting log generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->