### PR TITLE
feat(debug): add forced crash hotkey

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,6 +48,8 @@ set(sources
         src/Crash/CppException.h
         src/Crash/CrashHandler.cpp
         src/Crash/CrashHandler.h
+        src/Crash/CrashTests.cpp
+        src/Crash/CrashTests.h
         src/Crash/ThreadDump.cpp
         src/Crash/ThreadDump.h
         src/Crash/CommonHeader.cpp

--- a/src/Crash/CrashHandler.cpp
+++ b/src/Crash/CrashHandler.cpp
@@ -1702,6 +1702,16 @@ next_label:;
 		// Start hotkey monitoring thread
 		StartHotkeyMonitoring();
 
+		// Display warning if crash test hotkey is enabled
+		if (Settings::GetSingleton()->GetDebug().enableCrashTestHotkey) {
+			logger::warn("========================================");
+			logger::warn("WARNING: CRASH TEST HOTKEY ENABLED!");
+			logger::warn("Developer crash testing is active.");
+			logger::warn("The game will display a warning and can be crashed on demand.");
+			logger::warn("Disable 'Enable Crash Test Hotkey' in CrashLogger.ini for normal gameplay!");
+			logger::warn("========================================");
+		}
+
 // Verify handlers are working by testing (in debug builds only)
 #ifdef _DEBUG
 		if (const auto& debugConfig = Settings::GetSingleton()->GetDebug();
@@ -1710,4 +1720,5 @@ next_label:;
 		}
 #endif
 	}
+
 }  // namespace Crash

--- a/src/Crash/CrashHandler.h
+++ b/src/Crash/CrashHandler.h
@@ -53,4 +53,7 @@ namespace Crash
 	};
 
 	void Install(std::string a_crashPath);
+
+	// Developer crash testing functions
+	void TriggerTestCrash(int crashType);
 }

--- a/src/Crash/CrashTests.cpp
+++ b/src/Crash/CrashTests.cpp
@@ -1,0 +1,231 @@
+#include "Crash/CrashTests.h"
+
+#include <stdexcept>
+
+namespace Crash
+{
+	namespace CrashTests
+	{
+		namespace
+		{
+			// ============================================================================
+			// General C++ Crash Helpers
+			// ============================================================================
+
+			// Helper to cause divide by zero
+			__declspec(noinline) int CauseDivideByZero()
+			{
+				volatile int divisor = 0;
+				volatile int dividend = 42;
+				return dividend / divisor;  // Integer divide by zero
+			}
+
+			// Helper class for testing virtual function call on corrupted object
+			class VirtualFunctionTester
+			{
+			public:
+				virtual ~VirtualFunctionTester() = default;
+				virtual void DoSomething()
+				{
+					// This will never execute in our test
+				}
+			};
+
+			// ============================================================================
+			// Skyrim-Specific Crash Helpers
+			// ============================================================================
+
+			// Helper to cause invalid form access (NULL form pointer)
+			__declspec(noinline) void CauseInvalidFormAccess()
+			{
+				// Simulate accessing a NULL TESForm pointer - very common crash
+				RE::TESForm* form = nullptr;
+				volatile auto formID = form->GetFormID();  // Crash: null pointer dereference
+				(void)formID;
+			}
+
+			// Helper to cause invalid 3D access (NULL NiAVObject)
+			__declspec(noinline) void CauseInvalid3DAccess()
+			{
+				// Simulate accessing NULL 3D object - common when actors are loaded but 3D isn't ready
+				RE::NiAVObject* node = nullptr;
+				volatile auto pos = node->world.translate;  // Crash: null pointer dereference
+				(void)pos;
+			}
+
+			// Helper to cause invalid ExtraDataList access
+			__declspec(noinline) void CauseInvalidExtraDataAccess()
+			{
+				// Simulate accessing NULL ExtraDataList
+				RE::ExtraDataList* extraList = nullptr;
+				volatile bool hasData = extraList->HasType(RE::ExtraDataType::kCount);  // Crash
+				(void)hasData;
+			}
+
+			// Helper to corrupt PlayerCharacter singleton
+			__declspec(noinline) void CauseCorruptedPlayerSingleton()
+			{
+				// Get the real PlayerCharacter singleton
+				auto player = RE::PlayerCharacter::GetSingleton();
+				if (!player) {
+					// If we can't get player, just cause a null dereference anyway
+					RE::PlayerCharacter* nullPlayer = nullptr;
+					volatile auto formID = nullPlayer->GetFormID();
+					(void)formID;
+					return;
+				}
+
+				// Corrupt the vtable pointer (first 8 bytes of the object)
+				// This simulates memory corruption that can happen with bad pointers
+				auto corruptedVTable = reinterpret_cast<void***>(player);
+				*corruptedVTable = reinterpret_cast<void**>(0xDEADBEEF);
+
+				// Now try to call a virtual function - this will crash
+				volatile auto formID = player->GetFormID();  // Crashes trying to use corrupted vtable
+				(void)formID;
+			}
+
+			// Helper to call with wrong offset (simulate version mismatch)
+			__declspec(noinline) void CauseWrongOffsetAccess()
+			{
+				// Get PlayerCharacter singleton
+				auto player = RE::PlayerCharacter::GetSingleton();
+				if (!player) {
+					// If we can't get player, cause null dereference
+					RE::PlayerCharacter* nullPlayer = nullptr;
+					volatile auto formID = nullPlayer->GetFormID();
+					(void)formID;
+					return;
+				}
+
+				// Simulate accessing wrong offset (like using SE offsets in AE or vice versa)
+				// We'll try to read a NiNode* from a bogus offset
+				// PlayerCharacter is at least 0x800 bytes, so offset 0x1000 is definitely wrong
+				auto bogusOffset = reinterpret_cast<uintptr_t>(player) + 0x1000;  // Way past actual object size
+				auto fakeNodePtr = reinterpret_cast<RE::NiNode**>(bogusOffset);
+
+				// Try to dereference it - will read garbage or unmapped memory
+				volatile auto node = *fakeNodePtr;  // May crash here
+				if (node) {
+					// If it didn't crash yet, try to use the garbage pointer
+					volatile auto pos = node->world.translate;  // Definitely crashes here
+					(void)pos;
+				}
+			}
+		}
+
+		// Crash type names (no emojis for Skyrim compatibility)
+		const char* GetCrashTypeName(int crashType)
+		{
+			static const char* crashTypeNames[] = {
+				"[0] Access Violation (invalid write)",
+				"[1] Null Pointer Dereference",
+				"[2] C++ Exception (std::runtime_error)",
+				"[3] Divide by Zero",
+				"[4] Invalid Virtual Call (corrupted object)",
+				"[5] Invalid Form Access (NULL TESForm)",
+				"[6] Invalid 3D Access (NULL NiAVObject)",
+				"[7] Invalid ExtraData (NULL ExtraDataList)",
+				"[8] Corrupted Player Singleton (vtable corruption)",
+				"[9] Wrong Offset Access (version mismatch)"
+			};
+
+			if (crashType >= 0 && crashType < GetCrashTestCount()) {
+				return crashTypeNames[crashType];
+			}
+			return "[?] Unknown";
+		}
+
+		void TriggerTestCrash(int crashType)
+		{
+			logger::info("Developer crash test triggered: type {}", crashType);
+
+			switch (crashType) {
+			case 0:  // Access Violation (invalid write)
+				{
+					logger::info("Triggering Access Violation (write to invalid address)");
+					volatile int* ptr = reinterpret_cast<volatile int*>(0xDEADBEEF);
+					*ptr = 42;  // Write to invalid memory
+					break;
+				}
+
+			case 1:  // Null Pointer Dereference
+				{
+					logger::info("Triggering Null Pointer Dereference");
+					volatile int* ptr = nullptr;
+					volatile int value = *ptr;  // Read from null pointer
+					(void)value;
+					break;
+				}
+
+			case 2:  // C++ Exception
+				{
+					logger::info("Triggering C++ Exception (std::runtime_error)");
+					throw std::runtime_error("CrashLogger Test Exception: This is an intentional crash for testing!");
+				}
+
+			case 3:  // Divide by Zero
+				{
+					logger::info("Triggering Divide by Zero");
+					volatile int result = CauseDivideByZero();
+					(void)result;
+					break;
+				}
+
+			case 4:  // Invalid Virtual Call (Corrupted Object)
+				{
+					logger::info("Triggering Invalid Virtual Call");
+					// Create a pointer to an object with corrupted vtable
+					// This simulates calling a virtual function on a corrupted object
+					VirtualFunctionTester* ptr = reinterpret_cast<VirtualFunctionTester*>(0x1000);
+					// This will crash trying to access the vtable
+					ptr->DoSomething();
+					break;
+				}
+
+			case 5:  // Invalid Form Access (Skyrim-specific)
+				{
+					logger::info("Triggering Invalid Form Access (NULL TESForm)");
+					CauseInvalidFormAccess();
+					break;
+				}
+
+			case 6:  // Invalid 3D Access (Skyrim-specific)
+				{
+					logger::info("Triggering Invalid 3D Access (NULL NiAVObject)");
+					CauseInvalid3DAccess();
+					break;
+				}
+
+			case 7:  // Invalid ExtraData Access (Skyrim-specific)
+				{
+					logger::info("Triggering Invalid ExtraData Access (NULL ExtraDataList)");
+					CauseInvalidExtraDataAccess();
+					break;
+				}
+
+			case 8:  // Corrupted Player Singleton
+				{
+					logger::info("Triggering Corrupted Player Singleton (vtable corruption)");
+					logger::warn("WARNING: This will corrupt the player object! Game may be unstable if crash log completes.");
+					CauseCorruptedPlayerSingleton();
+					break;
+				}
+
+			case 9:  // Wrong Offset Access (version mismatch simulation)
+				{
+					logger::info("Triggering Wrong Offset Access (simulates version mismatch)");
+					CauseWrongOffsetAccess();
+					break;
+				}
+
+			default:
+				logger::warn("Invalid crash test type: {}", crashType);
+				break;
+			}
+
+			// Should never reach here
+			logger::error("Crash test did not trigger a crash!");
+		}
+	}
+}

--- a/src/Crash/CrashTests.h
+++ b/src/Crash/CrashTests.h
@@ -1,0 +1,18 @@
+#pragma once
+
+namespace Crash
+{
+	namespace CrashTests
+	{
+		// Trigger a developer crash test of the specified type
+		// Types 0-4: General C++ crashes
+		// Types 5-9: Skyrim-specific crashes
+		void TriggerTestCrash(int crashType);
+
+		// Get the number of available crash test types
+		constexpr int GetCrashTestCount() { return 10; }
+
+		// Get crash type names for display
+		const char* GetCrashTypeName(int crashType);
+	}
+}

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -58,7 +58,7 @@ void Settings::Debug::Load(CSimpleIniA& a_ini)
 	get_value(a_ini, enableThreadDumpHotkey, section, "Enable Thread Dump Hotkey", ";Enable thread dump hotkey for diagnosing hangs/deadlocks. Default: true\n;When enabled, press Ctrl+Shift+F12 while game is frozen to generate dump.\n;Set to 0 to disable (no monitoring thread will be created).");
 
 	// Parse hotkey combination (comma-separated list of VK codes)
-	std::string hotkeyStr;
+	std::string hotkeyStr = "17, 16, 123";  // Default: Ctrl+Shift+F12
 	get_value(a_ini, hotkeyStr, section, "Thread Dump Hotkey", ";Hotkey combination (VK codes): Ctrl=17, Shift=16, F12=123. Default: 17, 16, 123\n;VK code reference: https://learn.microsoft.com/en-us/windows/win32/inputdev/virtual-key-codes");
 
 	// Heap analysis section header
@@ -128,6 +128,25 @@ void Settings::Debug::Load(CSimpleIniA& a_ini)
 		}
 	}
 
+	// Developer crash testing section header
+	a_ini.SetValue(section, nullptr, nullptr,
+		"\n; ============================================================================\n"
+		"; Developer Crash Testing (FOR TESTING ONLY - KEEP DISABLED!)\n"
+		"; ============================================================================\n"
+		"; WARNING: These features intentionally CRASH the game for testing!\n"
+		"; Only enable these if you're testing CrashLogger functionality.\n"
+		"; DO NOT enable these during normal gameplay!\n"
+		"; ============================================================================",
+		false);
+
+	get_value(a_ini, enableCrashTestHotkey, section, "Enable Crash Test Hotkey", ";Enable developer crash testing hotkey. Default: false\n;WARNING: This will display a prominent warning on screen and intentionally crash when pressed!\n;Only enable for testing CrashLogger. DO NOT enable during normal gameplay!\n;Set to false or 0 to disable completely.");
+
+	// Parse crash test hotkey combination
+	std::string crashTestHotkeyStr = "17, 16, 122";  // Default: Ctrl+Shift+F11
+	get_value(a_ini, crashTestHotkeyStr, section, "Crash Test Hotkey", ";Crash test hotkey combination (VK codes): Ctrl=17, Shift=16, F11=122. Default: 17, 16, 122\n;Press this combination to trigger a test crash (only if enabled above).\n;Use Ctrl+Shift+PgUp/PgDn to cycle between crash types in-game!");
+
+	get_value(a_ini, crashTestType, section, "Crash Test Type", ";Initial crash type on game start (0-9). Can be changed in-game with Ctrl+Shift+PgUp/PgDn. Default: 0\n;General C++ Crashes:\n;  0 = Access Violation (invalid memory write)\n;  1 = Null Pointer Dereference (read from address 0)\n;  2 = C++ Exception (std::runtime_error with message)\n;  3 = Divide by Zero (integer division)\n;  4 = Invalid Virtual Call (corrupted object vtable)\n;Skyrim-Specific Crashes:\n;  5 = Invalid Form Access (NULL TESForm pointer)\n;  6 = Invalid 3D Access (NULL NiAVObject pointer)\n;  7 = Invalid ExtraData (NULL ExtraDataList pointer)\n;  8 = Corrupted Player Singleton (vtable corruption)\n;  9 = Wrong Offset Access (simulates version mismatch)\n;TIP: Don't edit this while testing - use PgUp/PgDn hotkeys instead!");
+
 	// Advanced section header
 	a_ini.SetValue(section, nullptr, nullptr,
 		"\n; ============================================================================\n"
@@ -152,6 +171,24 @@ void Settings::Debug::Load(CSimpleIniA& a_ini)
 			if (!token.empty()) {
 				try {
 					threadDumpHotkey.push_back(std::stoi(token));
+				} catch (...) {
+					// Skip invalid values
+				}
+			}
+		}
+	}
+
+	crashTestHotkey.clear();
+	if (!crashTestHotkeyStr.empty()) {
+		std::istringstream iss(crashTestHotkeyStr);
+		std::string token;
+		while (std::getline(iss, token, ',')) {
+			// Trim whitespace
+			token.erase(0, token.find_first_not_of(" \t"));
+			token.erase(token.find_last_not_of(" \t") + 1);
+			if (!token.empty()) {
+				try {
+					crashTestHotkey.push_back(std::stoi(token));
 				} catch (...) {
 					// Skip invalid values
 				}

--- a/src/Settings.h
+++ b/src/Settings.h
@@ -32,6 +32,11 @@ public:
 
 		// Thread context heuristics (label -> list of keywords)
 		std::vector<std::pair<std::string, std::vector<std::string>>> threadContextHeuristics;
+
+		// Developer crash testing features
+		bool enableCrashTestHotkey{ false };
+		std::vector<int> crashTestHotkey{ VK_CONTROL, VK_SHIFT, VK_F11 };
+		int crashTestType{ 0 };  // 0=access violation, 1=null deref, 2=C++ exception, 3=stack overflow, 4=divide by zero, 5=pure virtual call
 	};
 
 	[[nodiscard]] static Settings* GetSingleton();


### PR DESCRIPTION
Enable in ini. Not intended for real playthroughs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable crash testing hotkey (Ctrl+Shift+F11) with runtime crash type selection.
  * Added thread dump hotkey (Ctrl+Shift+F12) for diagnostic capture.
  * Added ability to cycle through crash test types in-game via hotkey combinations.
  * Added warning messages when crash testing is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->