### PR TITLE
ci: harden PR build + check-nexus

### DIFF
--- a/.github/workflows/build-reusable.yml
+++ b/.github/workflows/build-reusable.yml
@@ -139,7 +139,7 @@ jobs:
 
       - name: Upload artifact
         if: inputs.upload-artifact
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ steps.artifact_info.outputs.artifact-name }}
           path: ${{ steps.artifact_info.outputs.artifact-path }}

--- a/.github/workflows/build-reusable.yml
+++ b/.github/workflows/build-reusable.yml
@@ -45,12 +45,16 @@ jobs:
     name: Build on Windows
     runs-on: windows-latest
     if: github.repository_owner == 'alandtse'
+    timeout-minutes: 60
+    permissions:
+      contents: read
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           submodules: "recursive"
           ref: ${{ inputs.ref || github.sha }}
+          persist-credentials: false
 
       - name: Extract vcpkg baseline from vcpkg.json
         id: vcpkg_baseline
@@ -61,10 +65,10 @@ jobs:
           echo "baseline=$baseline" >> $env:GITHUB_OUTPUT
           echo "Using vcpkg baseline from vcpkg.json: $baseline"
 
-      - uses: lukka/get-cmake@latest
+      - uses: lukka/get-cmake@591817e96fcad43505fb4eae36172462abb3a42e # v4.3.3
 
       - name: Restore artifacts, or setup vcpkg (do not install any package)
-        uses: lukka/run-vcpkg@v11
+        uses: lukka/run-vcpkg@b1a0dd252f06b9e25b3c022a9a03bd7a427fb6a2 # v11
         id: runvcpkg
         with:
           vcpkgDirectory: "${{ github.workspace }}/b/vcpkg"
@@ -75,7 +79,7 @@ jobs:
         run: echo "root='${{ steps.runvcpkg.outputs.RUNVCPKG_VCPKG_ROOT_OUT }}', triplet='${{ steps.runvcpkg.outputs.RUNVCPKG_VCPKG_DEFAULT_TRIPLET_OUT }}'"
 
       - name: Run CMake with vcpkg.json manifest
-        uses: lukka/run-cmake@v10
+        uses: lukka/run-cmake@5d55ea7949e25f69f0ecb516d8d572297e03a956 # v10
         with:
           cmakeListsTxtPath: "${{ github.workspace }}/CMakeLists.txt"
           configurePreset: ${{ inputs.preset }}
@@ -135,7 +139,7 @@ jobs:
 
       - name: Upload artifact
         if: inputs.upload-artifact
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: ${{ steps.artifact_info.outputs.artifact-name }}
           path: ${{ steps.artifact_info.outputs.artifact-path }}

--- a/.github/workflows/check-nexus.yml
+++ b/.github/workflows/check-nexus.yml
@@ -3,12 +3,18 @@ name: Check Nexus Credentials
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   check-credentials:
     runs-on: ubuntu-latest
+    if: github.repository_owner == 'alandtse'
+    permissions:
+      contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup UNEX
         uses: alandtse/nexus-workflows/.github/actions/setup-unex@main

--- a/.github/workflows/check-nexus.yml
+++ b/.github/workflows/check-nexus.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Setup UNEX
         uses: alandtse/nexus-workflows/.github/actions/setup-unex@main

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -21,10 +21,24 @@ on:
       - '.github/workflows/build-reusable.yml'
       - '.github/workflows/pr-test.yml'
 
+# Least-privilege default token; passed through to the reusable build, which only
+# checks out and compiles and needs no write scopes.
+permissions:
+  contents: read
+
+# Cancel a superseded run when the PR is force-pushed (keyed on PR number).
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   test-build:
     name: Test Build
     uses: ./.github/workflows/build-reusable.yml
+    # Explicit least-privilege at the call site (pass-through to the reusable).
+    permissions:
+      contents: read
     with:
       preset: Release-MSVC
       upload-artifact: false
+    # No `secrets:` block — intentional: keeps fork PRs in a zero-secret context.


### PR DESCRIPTION
@
Backports the EngineFixes CI hardening posture (CommunityShaders-style).

### `pr-test.yml` (caller-side)
- top-level + per-job `permissions: contents: read`
- `concurrency` with `cancel-in-progress` (force-push cancels the stale build)
- stays on `pull_request` with no `secrets:` → zero-secret fork context

### `build-reusable.yml` (step-side; covers PR and release builds)
- `timeout-minutes: 60`, job `permissions: contents: read`
- `persist-credentials: false` on checkout
- **all third-party actions SHA-pinned**: `checkout@v6`, `get-cmake` (→v4.3.3, was `@latest`), `run-vcpkg@v11`, `run-cmake@v10`, `upload-artifact@v6`

### `check-nexus.yml`
- add `if: github.repository_owner == alandtse` guard + `permissions: contents: read`
- pin `actions/checkout@v6` to its SHA
- own-repo `nexus-workflows` actions kept `@main` (they postdate tag `v1.4.0`)

Mirrors alandtse/EngineFixesSkyrim64#4. No build-logic changes (DRY — `pr-test` still reuses `build-reusable`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@