### PR TITLE
ci: enable vcpkg binary caching

### DIFF
--- a/.github/workflows/build-reusable.yml
+++ b/.github/workflows/build-reusable.yml
@@ -49,6 +49,9 @@ jobs:
     permissions:
       contents: read
 
+    env:
+      VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"
+
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -77,6 +80,15 @@ jobs:
 
       - name: Prints output of run-vcpkg's action
         run: echo "root='${{ steps.runvcpkg.outputs.RUNVCPKG_VCPKG_ROOT_OUT }}', triplet='${{ steps.runvcpkg.outputs.RUNVCPKG_VCPKG_DEFAULT_TRIPLET_OUT }}'"
+
+      # x-gha reads the Actions cache endpoint from these two variables, which GitHub
+      # only exposes to the github-script runtime — re-export them so vcpkg sees them.
+      - name: Enable vcpkg GitHub Actions binary cache
+        uses: actions/github-script@v7
+        with:
+          script: |
+            core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
+            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
 
       - name: Run CMake with vcpkg.json manifest
         uses: lukka/run-cmake@5d55ea7949e25f69f0ecb516d8d572297e03a956 # v10


### PR DESCRIPTION
## Why

CI currently has no vcpkg binary-source configuration, so every run recompiles all vcpkg dependencies from source — slow and wasteful.

## What

- Adds job-level `env: VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"` so vcpkg reads/writes prebuilt dependency `.libs` to the GitHub Actions cache.
- Adds an `actions/github-script` step immediately before `lukka/run-cmake@v10` that re-exports `ACTIONS_CACHE_URL` and `ACTIONS_RUNTIME_TOKEN`. GitHub only exposes these to the github-script runtime, so vcpkg's `x-gha` provider cannot reach the Actions cache service without re-exporting them into the job environment.

The cmake step performs the vcpkg manifest install, so populating the binary cache before it runs lets a warm cache turn a dependency build into a near-instant (~ms) restore. First run seeds the cache; subsequent runs restore.

Validated locally as valid YAML. Only `.github/workflows/build-reusable.yml` is changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)