### PR TITLE
feat: null-call self-heal, stack-overflow survival, PDB diagnostics

### DIFF
--- a/scripts/package_skyrim_pdbs.py
+++ b/scripts/package_skyrim_pdbs.py
@@ -134,6 +134,9 @@ def parse_args():
 def main():
     args = parse_args()
     sevenzip = find_7z(args.sevenzip)
+    # Absolute-ize: package_runtime runs 7z with cwd=<stage>, so a relative archive path would be
+    # resolved against the stage dir (nested) and the later getsize would miss it.
+    args.out = os.path.abspath(args.out)
     os.makedirs(args.out, exist_ok=True)
 
     print(f"Packaging Skyrim PDBs -> {args.out}")

--- a/src/Crash/Analysis.cpp
+++ b/src/Crash/Analysis.cpp
@@ -316,6 +316,72 @@ namespace Crash
 		print_callstack_impl(a_log, frame_data, "\t"sv);
 	}
 
+	namespace
+	{
+		// Reseed a reliable virtual unwind from the return address a faulting CALL pushed at [RSP].
+		// Used to recover the true caller chain of a null/near-null indirect call, where the normal
+		// unwinder dead-ends because the fault frame's RIP (=0) has no unwind metadata.
+		//
+		// Kept free of any object that requires unwinding (no std:: containers, no destructors) so
+		// the function is legal to wrap in __try/__except (MSVC C2712). Results are written into the
+		// caller-provided buffer, mirroring safe_collect_native_frames().
+		bool safe_reseed_unwind_from_rsp(const ::CONTEXT& a_context, void** a_out, std::size_t a_max, std::size_t& a_count) noexcept
+		{
+			a_count = 0;
+			__try {
+				// The faulting CALL pushed its return address at [RSP]; that is the real caller.
+				const auto retSlot = reinterpret_cast<void* const*>(a_context.Rsp);
+				void* const caller = *retSlot;  // may fault if RSP is invalid -> caught below
+				if (caller == nullptr || a_max == 0) {
+					return true;
+				}
+
+				// Synthesize a context positioned just past the faulting CALL and unwind from there.
+				::CONTEXT ctx = a_context;
+				ctx.Rip = reinterpret_cast<DWORD64>(caller);
+				ctx.Rsp = a_context.Rsp + sizeof(void*);
+
+				a_out[a_count++] = caller;
+
+				while (a_count < a_max && ctx.Rip != 0) {
+					DWORD64 imageBase = 0;
+					auto* const fn = ::RtlLookupFunctionEntry(ctx.Rip, &imageBase, nullptr);
+					if (fn == nullptr) {
+						break;  // leaf function / no unwind data -> stop the reliable walk
+					}
+
+					PVOID handlerData = nullptr;
+					DWORD64 establisherFrame = 0;
+					::RtlVirtualUnwind(UNW_FLAG_NHANDLER, imageBase, ctx.Rip, fn, &ctx,
+						&handlerData, &establisherFrame, nullptr);
+
+					if (ctx.Rip == 0) {
+						break;
+					}
+					a_out[a_count++] = reinterpret_cast<void*>(ctx.Rip);
+				}
+				return true;
+			} __except (EXCEPTION_EXECUTE_HANDLER) {
+				return false;  // stack walk faulted; caller keeps whatever was collected
+			}
+		}
+	}
+
+	std::vector<const void*> recover_null_call_stack(const ::CONTEXT& a_context, std::size_t a_max_frames)
+	{
+		std::vector<const void*> result;
+		if (a_max_frames == 0) {
+			return result;
+		}
+
+		std::vector<void*> buffer(a_max_frames, nullptr);
+		std::size_t count = 0;
+		if (safe_reseed_unwind_from_rsp(a_context, buffer.data(), a_max_frames, count)) {
+			result.assign(buffer.begin(), buffer.begin() + count);
+		}
+		return result;
+	}
+
 	std::vector<const void*> scan_stack_for_frames(
 		std::span<const std::size_t> a_stack,
 		std::span<const module_pointer> a_modules,

--- a/src/Crash/Analysis.h
+++ b/src/Crash/Analysis.h
@@ -108,6 +108,14 @@ namespace Crash
 		std::span<const void* const> a_frames,
 		std::span<const module_pointer> a_modules);
 
+	// Recover the real caller chain of a null/near-null indirect call (execute access violation at
+	// RIP≈0). The faulting CALL pushed its return address at [RSP], which has valid unwind metadata,
+	// so a reliable virtual unwind can be reseeded from it. Returns frames starting at the caller of
+	// the faulting CALL; empty if RSP is invalid or no caller could be recovered.
+	[[nodiscard]] std::vector<const void*> recover_null_call_stack(
+		const ::CONTEXT& a_context,
+		std::size_t a_max_frames = 128);
+
 	// Scan raw stack data for plausible return addresses and build a reconstructed callstack
 	[[nodiscard]] std::vector<const void*> scan_stack_for_frames(
 		std::span<const std::size_t> a_stack,

--- a/src/Crash/CrashHandler.cpp
+++ b/src/Crash/CrashHandler.cpp
@@ -1459,6 +1459,17 @@ next_label:;
 
 		std::int32_t __stdcall UnhandledExceptions(::EXCEPTION_POINTERS* a_exception) noexcept
 		{
+			// Stack overflow path: when the original crash is a stack overflow, the
+			// thread has run past its guard page, so any subsequent code that pushes
+			// non-trivial stack frames (notably safe_capture_stacktrace's 4 KB local
+			// buffer + boost::stacktrace symbol resolution) faults again and we lose
+			// the report. _resetstkoflw() commits a fresh guard page so the rest of
+			// the handler has stack to run on. Must be called as early as possible.
+			if (a_exception && a_exception->ExceptionRecord &&
+				a_exception->ExceptionRecord->ExceptionCode == static_cast<DWORD>(EXCEPTION_STACK_OVERFLOW)) {
+				::_resetstkoflw();
+			}
+
 			// Install the SEH-to-C++ exception translator
 			_set_se_translator(seh_translator);
 
@@ -1781,6 +1792,16 @@ next_label:;
 		if (!a_crashPath.empty()) {
 			crashPath = std::filesystem::path(a_crashPath);
 			logger::info("Crash Logs will be written to {}", crashPath.string());
+		}
+
+		// Reserve a slice of stack guaranteed to be available when an exception
+		// handler runs. Without this, a stack-overflow crash leaves the handler
+		// with too little stack to capture the stacktrace and we observe
+		// recursive crashes inside CrashLogger itself. 64 KB is enough for the
+		// safe_capture_stacktrace + boost::stacktrace + spdlog write path.
+		{
+			ULONG stackGuarantee = 64 * 1024;
+			::SetThreadStackGuarantee(&stackGuarantee);
 		}
 
 		// Install crash handlers

--- a/src/Crash/CrashHandler.cpp
+++ b/src/Crash/CrashHandler.cpp
@@ -101,8 +101,36 @@ namespace Crash
 		}
 	}
 
-	Callstack::Callstack(const ::EXCEPTION_RECORD& a_except)
+	Callstack::Callstack(const ::EXCEPTION_RECORD& a_except, const ::CONTEXT* a_context)
 	{
+		// Self-heal for a null / near-null EXECUTE access violation (a call through a null or
+		// garbage function pointer). RtlCaptureStackBackTrace, called from inside this handler,
+		// would return only the handler + OS exception-dispatch frames, because the faulting
+		// frame's RIP (=0) has no unwind metadata for the walk to cross. The faulting CALL did
+		// push its return address at [RSP], whose code has valid unwind data, so reseed a reliable
+		// unwind from there: the resulting frames ARE the real culprit chain. We replace the
+		// captured frames entirely so every consumer (hybrid stack, throw location, thread role)
+		// sees the corrected stack instead of the handler.
+		const auto exceptionIp = reinterpret_cast<std::uintptr_t>(a_except.ExceptionAddress);
+		const bool isNullCall =
+			a_except.ExceptionCode == EXCEPTION_ACCESS_VIOLATION &&
+			a_except.NumberParameters >= 1 &&
+			a_except.ExceptionInformation[0] == 8 &&  // execute
+			exceptionIp < 0x10000;
+
+		if (isNullCall && a_context) {
+			const auto recovered = recover_null_call_stack(*a_context);
+			if (!recovered.empty()) {
+				_capturedFrames.clear();
+				_capturedFrames.reserve(recovered.size());
+				for (const auto addr : recovered) {
+					_capturedFrames.emplace_back(addr);
+				}
+				_frames = std::span(_capturedFrames);
+				return;
+			}
+		}
+
 		auto [capturedFrames, success] = safe_capture_stacktrace();
 		_capturedFrames = std::move(capturedFrames);
 
@@ -508,12 +536,48 @@ namespace Crash
 			}
 		}
 
+		// Handle a null / near-null EXECUTE access violation: a call/jmp through a null (or garbage)
+		// function pointer. There is nothing to disassemble at the fault IP, and the reliable stack
+		// unwinder cannot cross a frame whose RIP has no unwind metadata, so the probable callstack
+		// dead-ends in the OS exception dispatcher and the CrashLogger/ntdll frames at the top are the
+		// handler, not the cause. The faulting CALL did push its return address at [RSP], though, so
+		// we reseed a reliable unwind from there to name the true caller chain.
+		//
+		// Returns true if the violation was a null call. The corrected call stack itself is produced
+		// by Callstack (reseeded from [RSP]); here we only annotate WHY the stack was healed, so the
+		// reader knows the OS-dispatch / CrashLogger handler frames were deliberately omitted.
+		bool print_null_call_analysis(
+			spdlog::logger& a_log,
+			const ::EXCEPTION_RECORD& a_exception)
+		{
+			const auto ipValue = reinterpret_cast<std::uintptr_t>(a_exception.ExceptionAddress);
+			const bool isExecute = a_exception.ExceptionInformation[0] == 8;
+			if (!isExecute || ipValue >= 0x10000) {
+				return false;
+			}
+
+			a_log.critical("ACCESS VIOLATION ANALYSIS:"sv);
+			a_log.critical("\tRIP = 0x{:X} -- null function-pointer call (executed an unmapped address)."sv, ipValue);
+			a_log.critical("\tThe faulting frame has no unwind data, so the primary call stack below has"sv);
+			a_log.critical("\tbeen reseeded from the return address at [RSP]; the OS exception-dispatch"sv);
+			a_log.critical("\tand CrashLogger handler frames are omitted as they are not the cause."sv);
+			return true;
+		}
+
 		void print_access_violation_analysis(
 			spdlog::logger& a_log,
 			const ::EXCEPTION_RECORD& a_exception,
 			const ::CONTEXT& a_context)
 		{
 			const auto ip = a_exception.ExceptionAddress;
+
+			// Null / near-null EXECUTE access violations (a call/jmp through a null function pointer)
+			// have nothing to disassemble at the fault IP, so they are annotated separately (the
+			// corrected call stack itself is reseeded inside Callstack).
+			if (print_null_call_analysis(a_log, a_exception)) {
+				return;
+			}
+
 			ZydisDisassembledInstruction instruction{};
 
 			// Guard against reading invalid memory at ExceptionAddress
@@ -1477,7 +1541,7 @@ next_label:;
 				std::optional<Callstack> callstack;
 				std::string throwLocation;
 				try {
-					callstack.emplace(*a_exception->ExceptionRecord);
+					callstack.emplace(*a_exception->ExceptionRecord, a_exception->ContextRecord);
 					if (IsCppException(*a_exception->ExceptionRecord)) {
 						throwLocation = callstack->get_throw_location(cmodules);
 					}
@@ -1533,7 +1597,7 @@ next_label:;
 				print([&]() {
 					try {
 						const Callstack* callstack_ptr = callstack ? &(*callstack) : nullptr;
-						Callstack fallback{ *a_exception->ExceptionRecord };
+						Callstack fallback{ *a_exception->ExceptionRecord, a_exception->ContextRecord };
 						if (!callstack_ptr) {
 							callstack_ptr = &fallback;
 						}

--- a/src/Crash/CrashHandler.h
+++ b/src/Crash/CrashHandler.h
@@ -3,6 +3,7 @@
 #include <vector>
 
 struct _EXCEPTION_RECORD;
+struct _CONTEXT;
 
 namespace Crash
 {
@@ -14,7 +15,9 @@ namespace Crash
 	class Callstack
 	{
 	public:
-		Callstack(const ::_EXCEPTION_RECORD& a_except);
+		// a_context (the faulting CONTEXT) enables self-healing the call stack for null
+		// function-pointer calls by reseeding the unwind from [RSP]; pass it when available.
+		Callstack(const ::_EXCEPTION_RECORD& a_except, const ::_CONTEXT* a_context = nullptr);
 
 		void print(
 			spdlog::logger& a_log,

--- a/src/Crash/Introspection/Introspection.cpp
+++ b/src/Crash/Introspection/Introspection.cpp
@@ -783,6 +783,66 @@ namespace Crash::Introspection::SSE
 							tab_depth),
 						quoted(filePath));
 			} catch (...) {}
+
+			// If filePath/inputFilePath are empty (e.g. NIF loaded from a BSA into a memory
+			// buffer), the underlying input stream still knows its resource name. Only walk it
+			// if iStr's vtable matches BSResourceNiBinaryStream — calling DoGetName on the wrong
+			// subclass from a crash handler would re-crash us.
+			try {
+				const auto iStr = object->iStr;
+				if (iStr) {
+					const auto vt = *reinterpret_cast<const std::uintptr_t*>(iStr);
+					if (vt == RE::VTABLE_BSResourceNiBinaryStream[0].address()) {
+						const auto brnbs = static_cast<const RE::BSResourceNiBinaryStream*>(iStr);
+						const auto stream = brnbs->stream.get();
+						if (stream) {
+							RE::BSFixedString resName;
+							stream->DoGetName(resName);
+							if (!resName.empty()) {
+								a_results.emplace_back(
+									fmt::format("{:\t>{}}streamName"sv, "", tab_depth),
+									quoted(resName.c_str()));
+							}
+						}
+					}
+				}
+			} catch (...) {}
+		}
+	};
+
+	class BSResourceNiBinaryStream
+	{
+	public:
+		using value_type = RE::BSResourceNiBinaryStream;
+
+		static void filter(
+			filter_results& a_results,
+			const void* a_ptr, int tab_depth = 0) noexcept
+		{
+			const auto object = static_cast<const value_type*>(a_ptr);
+			if (!object)
+				return;
+			try {
+				const auto stream = object->stream.get();
+				if (stream) {
+					RE::BSFixedString resName;
+					stream->DoGetName(resName);
+					if (!resName.empty()) {
+						a_results.emplace_back(
+							fmt::format("{:\t>{}}streamName"sv, "", tab_depth),
+							quoted(resName.c_str()));
+					}
+				}
+			} catch (...) {}
+
+			try {
+				const auto err = static_cast<std::uint32_t>(object->lastError);
+				if (err != 0) {
+					a_results.emplace_back(
+						fmt::format("{:\t>{}}lastError"sv, "", tab_depth),
+						fmt::format("{:#x}"sv, err));
+				}
+			} catch (...) {}
 		}
 	};
 
@@ -2854,6 +2914,7 @@ namespace Crash::Introspection
 				std::make_pair(".?AVNiSkinInstance@@"sv, SSE::NiSkinInstance::filter),
 				std::make_pair(".?AVNiSkinPartition@@"sv, SSE::NiSkinPartition::filter),
 				std::make_pair(".?AVNiStream@@"sv, SSE::NiStream::filter),
+				std::make_pair(".?AVBSResourceNiBinaryStream@@"sv, SSE::BSResourceNiBinaryStream::filter),
 				std::make_pair(".?AVNiTexture@@"sv, SSE::NiTexture::filter),
 				std::make_pair(".?AVObjectTypeInfo@BSScript@@"sv, SSE::BSScript::ObjectTypeInfo::filter),
 				std::make_pair(".?AV?$BSTCommonLLMessageQueue@UFunctionMessage@Internal@BSScript@@@@"sv, SSE::BSScript::Internal::FunctionMessageQueue::filter),

--- a/src/Crash/PDB/PdbHandler.cpp
+++ b/src/Crash/PDB/PdbHandler.cpp
@@ -547,6 +547,50 @@ namespace Crash
 			}
 		}
 
+		// Captures the actual PDB path DIA opens. loadDataForExe also searches the exe's own
+		// directory and symbol paths in addition to the searchPath we pass, so the file it loads
+		// is frequently NOT the one in that searchPath (e.g. it prefers a SkyrimVR.pdb sitting next
+		// to the exe over the Data/SKSE/Plugins copy). Logging only the searchPath is misleading;
+		// NotifyOpenPDB reports the real file. Restrict* methods return S_OK to keep the default
+		// (NULL-callback) access behavior. Stack-allocated for a synchronous loadDataForExe call,
+		// so AddRef/Release are no-ops.
+		class DiaLoadLogger : public IDiaLoadCallback2
+		{
+		public:
+			std::wstring openedPdb;
+
+			ULONG STDMETHODCALLTYPE AddRef() override { return 2; }
+			ULONG STDMETHODCALLTYPE Release() override { return 1; }
+			HRESULT STDMETHODCALLTYPE QueryInterface(REFIID riid, void** ppv) override
+			{
+				if (!ppv) {
+					return E_INVALIDARG;
+				}
+				if (riid == __uuidof(IUnknown) || riid == __uuidof(IDiaLoadCallback) || riid == __uuidof(IDiaLoadCallback2)) {
+					*ppv = static_cast<IDiaLoadCallback2*>(this);
+					return S_OK;
+				}
+				*ppv = nullptr;
+				return E_NOINTERFACE;
+			}
+
+			HRESULT STDMETHODCALLTYPE NotifyDebugDir(BOOL, DWORD, BYTE*) override { return S_OK; }
+			HRESULT STDMETHODCALLTYPE NotifyOpenDBG(LPCOLESTR, HRESULT) override { return S_OK; }
+			HRESULT STDMETHODCALLTYPE NotifyOpenPDB(LPCOLESTR a_pdbPath, HRESULT a_resultCode) override
+			{
+				if (SUCCEEDED(a_resultCode) && a_pdbPath) {
+					openedPdb = a_pdbPath;
+				}
+				return S_OK;
+			}
+			HRESULT STDMETHODCALLTYPE RestrictRegistryAccess() override { return S_OK; }
+			HRESULT STDMETHODCALLTYPE RestrictSymbolServerAccess() override { return S_OK; }
+			HRESULT STDMETHODCALLTYPE RestrictOriginalPathAccess() override { return S_OK; }
+			HRESULT STDMETHODCALLTYPE RestrictReferencePathAccess() override { return S_OK; }
+			HRESULT STDMETHODCALLTYPE RestrictDBGAccess() override { return S_OK; }
+			HRESULT STDMETHODCALLTYPE RestrictSystemRootAccess() override { return S_OK; }
+		};
+
 		// Helper struct to encapsulate PDB session setup
 		struct PdbSession
 		{
@@ -626,14 +670,17 @@ namespace Crash
 				}
 
 				// Try to load PDB
+				DiaLoadLogger loadLogger;
 				bool foundPDB = false;
 				for (const auto& path : searchPaths) {
 					std::wstring path_w = utf8_to_utf16(path);
 					wcsncpy(wszPath, path_w.c_str(), sizeof(wszPath) / sizeof(wchar_t));
 					wszPath[_MAX_PATH - 1] = L'\0';
 
-					logger::info("Attempting to find pdb for {}+{:07X} with path {}", a_name, a_offset, path);
-					hr = pSource->loadDataForExe(wszFilename, wszPath, NULL);
+					// `path` is only a searchPath hint; DIA also searches the exe's directory and
+					// symbol paths, so the file it actually opens is reported via loadLogger below.
+					logger::info("Attempting to load pdb for {}+{:07X} (searchPath {})", a_name, a_offset, path);
+					hr = pSource->loadDataForExe(wszFilename, wszPath, &loadLogger);
 					if (FAILED(hr)) {
 						auto error = print_hr_failure(hr);
 						logger::info("Failed to open pdb for dll {}+{:07X}\t{}", a_name, a_offset, error);
@@ -647,7 +694,12 @@ namespace Crash
 					return false;
 				}
 
-				logger::info("Successfully opened pdb for dll {}+{:07X}", a_name, a_offset);
+				if (!loadLogger.openedPdb.empty()) {
+					logger::info("Successfully opened pdb for dll {}+{:07X} from {}", a_name, a_offset,
+						std::filesystem::path(loadLogger.openedPdb).string());
+				} else {
+					logger::info("Successfully opened pdb for dll {}+{:07X}", a_name, a_offset);
+				}
 
 				// Open session
 				if (FAILED(hr = pSource->openSession(&pSession))) {

--- a/tools/diaprobe/.gitignore
+++ b/tools/diaprobe/.gitignore
@@ -1,0 +1,5 @@
+probe.exe
+*.exe
+*.obj
+*.ilk
+*.pdb

--- a/tools/diaprobe/README.md
+++ b/tools/diaprobe/README.md
@@ -1,0 +1,39 @@
+# diaprobe
+
+A tiny DIA tool that resolves a PDB's public symbols by RVA **exactly the way CrashLogger does**
+(`loadDataFromPdb` → `openSession` → `findSymbolByRVA(rva, SymTagPublicSymbol)`).
+
+Use it to verify a freshly generated PDB (from [pdbgen](../../scripts/package_skyrim_pdbs.py))
+actually resolves **before** packaging it. This catches a failure mode a name/string dump (or
+`llvm-pdbutil --publics`) cannot: a PDB can contain public-symbol *names* yet still fail
+`findSymbolByRVA` when its section headers / section map are malformed (e.g. the large-PE
+`SectionHdr` corruption that produced "No public symbol found" for every VR frame).
+
+## Build
+
+From an x64 Native Tools prompt (or after `vcvars64`):
+
+```bat
+cl /nologo /EHsc /std:c++17 probe.cpp ^
+   /I"%VSINSTALLDIR%DIA SDK\include" ^
+   /link "%VSINSTALLDIR%DIA SDK\lib\amd64\diaguids.lib" ole32.lib oleaut32.lib advapi32.lib
+```
+
+## Usage
+
+```bat
+probe <pdb> <rva-hex> [<rva-hex> ...]
+```
+
+`rva-hex` is the module-relative offset CrashLogger prints (`SkyrimVR.exe+0CBFD2A` -> `CBFD2A`).
+Exit code is 0 only if every RVA resolved.
+
+```text
+> probe "SkyrimVR.pdb" CBFD2A C9E13B
+PDB: SkyrimVR.pdb
+  RVA 0xCBFD2A -> PUBLIC 'BSCullingProcess::sub_140C79410' (@0xCBFC60)
+  RVA 0xC9E13B -> PUBLIC 'NiNode::OnVisible_140C58C70' (@0xC9E0D0)
+```
+
+`msdia140.dll` is located via `%MSDIA140_DLL%`, then `msdia140.dll` on PATH/cwd, then the
+Visual Studio DIA SDK default. Set `MSDIA140_DLL` to override.

--- a/tools/diaprobe/probe.cpp
+++ b/tools/diaprobe/probe.cpp
@@ -1,0 +1,98 @@
+// diaprobe — verify a PDB resolves public symbols by RVA the way CrashLogger does.
+//
+// CrashLogger's PdbHandler resolves call-stack frames with DIA:
+//   loadDataForExe / loadDataFromPdb -> openSession -> findSymbolByRVA(rva, SymTagPublicSymbol).
+// This tool reproduces exactly that lookup so you can confirm a freshly generated PDB
+// (e.g. from pdbgen) actually resolves before packaging it. A PDB can contain public-symbol
+// *names* (visible to llvm-pdbutil / a string dump) yet still fail findSymbolByRVA if its
+// section headers / section map are malformed — this probe catches that, a name dump does not.
+//
+// Build (x64 Native Tools / vcvars64):
+//   cl /nologo /EHsc /std:c++17 probe.cpp ^
+//      /I"%VSINSTALLDIR%DIA SDK\include" ^
+//      /link "%VSINSTALLDIR%DIA SDK\lib\amd64\diaguids.lib" ole32.lib oleaut32.lib advapi32.lib
+//
+// Usage:
+//   probe <pdb> <rva-hex> [<rva-hex> ...]
+// e.g.
+//   probe SkyrimVR.pdb CBFD2A C9E13B
+//
+// msdia140.dll is located via (in order): %MSDIA140_DLL%, msdia140.dll on PATH/cwd,
+// then the Visual Studio DIA SDK default. Override with MSDIA140_DLL if needed.
+#include <cstdio>
+#include <cstdlib>
+#include <cwchar>
+#include <dia2.h>
+#include <diacreate.h>
+
+static IDiaDataSource* create_source()
+{
+	const wchar_t* candidates[] = {
+		_wgetenv(L"MSDIA140_DLL"),
+		L"msdia140.dll",
+		L"F:\\Program Files\\Microsoft Visual Studio\\2022\\Community\\DIA SDK\\bin\\amd64\\msdia140.dll",
+	};
+	for (const wchar_t* dll : candidates) {
+		if (!dll || !*dll) {
+			continue;
+		}
+		IDiaDataSource* source = nullptr;
+		if (SUCCEEDED(NoRegCoCreate(dll, __uuidof(DiaSource), __uuidof(IDiaDataSource), (void**)&source))) {
+			return source;
+		}
+	}
+	return nullptr;
+}
+
+int wmain(int argc, wchar_t** argv)
+{
+	if (argc < 3) {
+		wprintf(L"usage: probe <pdb> <rva-hex> [<rva-hex> ...]\n");
+		return 2;
+	}
+	if (FAILED(CoInitialize(nullptr))) {
+		wprintf(L"CoInitialize failed\n");
+		return 1;
+	}
+
+	IDiaDataSource* source = create_source();
+	if (!source) {
+		wprintf(L"could not load msdia140.dll (set MSDIA140_DLL to its full path)\n");
+		return 1;
+	}
+
+	HRESULT hr = source->loadDataFromPdb(argv[1]);
+	if (FAILED(hr)) {
+		wprintf(L"loadDataFromPdb('%s') failed 0x%08lx\n", argv[1], hr);
+		return 1;
+	}
+
+	IDiaSession* session = nullptr;
+	if (FAILED(hr = source->openSession(&session))) {
+		wprintf(L"openSession failed 0x%08lx\n", hr);
+		return 1;
+	}
+
+	wprintf(L"PDB: %s\n", argv[1]);
+	int unresolved = 0;
+	for (int i = 2; i < argc; ++i) {
+		DWORD rva = (DWORD)wcstoul(argv[i], nullptr, 16);
+		IDiaSymbol* sym = nullptr;
+		hr = session->findSymbolByRVA(rva, SymTagPublicSymbol, &sym);
+		if (hr == S_OK && sym) {
+			BSTR name = nullptr;
+			sym->get_name(&name);
+			DWORD symrva = 0;
+			sym->get_relativeVirtualAddress(&symrva);
+			wprintf(L"  RVA 0x%06X -> PUBLIC '%s' (@0x%06X)\n", rva, name ? name : L"<null>", symrva);
+			if (name) {
+				SysFreeString(name);
+			}
+			sym->Release();
+		} else {
+			wprintf(L"  RVA 0x%06X -> NO PUBLIC SYMBOL (hr=0x%08lx)\n", rva, hr);
+			++unresolved;
+		}
+	}
+	return unresolved == 0 ? 0 : 1;
+}


### PR DESCRIPTION
Crash-handler robustness + PDB-pipeline accuracy. Land with **Rebase and merge** to preserve the individual commits.

## Crash handler
- **`feat(analysis): recover caller chain for null function-pointer calls`** — an execute AV at a null/near-null IP (call through a null fn pointer) leaves the reliable unwinder dead-ended in the OS dispatcher (RIP=0 has no unwind data), so the probable callstack showed only CrashLogger/ntdll frames. `Callstack` now self-heals: it reseeds a reliable `RtlVirtualUnwind` from the return address the faulting CALL pushed at `[RSP]`, so the primary call stack (and everything derived from it) reflects the real culprit. The access-violation analysis annotates that the handler frames were omitted.
- **`fix(handler): survive stack-overflow crashes`** — `_resetstkoflw()` on `EXCEPTION_STACK_OVERFLOW` + a 64 KB `SetThreadStackGuarantee`, so the handler has stack to capture the report instead of re-faulting.

## Introspection
- **`feat(introspection): add BSResourceNiBinaryStream stream name`** — surfaces the NIF resource/stream name (and lastError), vtable-guarded before any virtual call.

## PDB pipeline
- **`fix(pdb): log the actual PDB path DIA opens`** — `loadDataForExe` also searches the exe's own directory, so the file it loads is often not the one in the searchPath we pass (it prefers a `SkyrimVR.pdb` next to the exe over the `Data/SKSE/Plugins` copy). Now logs the real path via an `IDiaLoadCallback2`.
- **`tools: add diaprobe`** — a small DIA utility that reproduces CrashLogger's resolution (`loadDataFromPdb` -> `findSymbolByRVA SymTagPublicSymbol`) so a generated PDB can be verified to actually resolve before packaging. Catches malformed section headers/map that a name dump (`llvm-pdbutil --publics`) would miss.
- **`fix(scripts): absolute-ize package out dir`** — a relative `--out` made the archive path resolve against the per-runtime stage dir (nested) and the later getsize failed.

## Build
- **`build: bump CommonLibSSE-NG to 4.26.2`** — includes the `Create()` allocation-size fix and VR runtime-layout fixes.

Verified: all 5 presets build; the regenerated VR PDB resolves (`RVA 0xCBFD2A -> BSCullingProcess::sub_140C79410`) via diaprobe; all three runtime PDBs repackage cleanly.