### PR TITLE
fix(build): align fmt/spdlog with CommonLib 4.26.2

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -51,11 +51,11 @@
   "overrides": [
     {
       "name": "fmt",
-      "version": "11.0.2"
+      "version": "12.1.0"
     },
     {
       "name": "spdlog",
-      "version": "1.15.0"
+      "version": "1.16.0"
     }
   ]
 }


### PR DESCRIPTION
## Problem
`v1.23.0` was tagged + a GitHub release created, but the **Build Release** job failed at link with `LNK2001`/`LNK1120` (`fmt::v12::…`, `spdlog::details::log_msg(... fmt::v12::basic_string_view ...)`) → **no DLL asset, Nexus upload skipped**.

## Cause
The CommonLib bump to 4.26.2 (#33) requires **fmt >= 12.1.0 / spdlog >= 1.16.0**, but `vcpkg.json` still force-pinned **fmt 11.0.2 / spdlog 1.15.0** via `overrides`. A clean manifest resolve (CI) then links `CommonLibSSE.lib` (built against fmt v12) against fmt v11 → unresolved externals. Local builds linked only because their cached `vcpkg_installed` was self-consistent.

## Fix
Bump the overrides to `fmt 12.1.0` / `spdlog 1.16.0` (both already present at the pinned `builtin-baseline`, so no baseline change needed).

## Verification
Clean from-scratch vcpkg build (deleted `vcpkg_installed`, re-resolved): vcpkg installs `fmt@12.1.0` + `spdlog@1.16.0` and **`CrashLogger.dll` links** with zero unresolved externals.