### PR TITLE
fix(settings): defaults being ignored on load

### DIFF
--- a/src/Crash/ThreadDump.cpp
+++ b/src/Crash/ThreadDump.cpp
@@ -358,7 +358,30 @@ namespace Crash
 
 		g_stopHotkeyThread = false;
 		g_hotkeyThread = std::jthread(HotkeyMonitorThreadFunction);
-		logger::info("Thread dump hotkey monitoring started (Ctrl+Shift+F12)"sv);
+
+		std::string hotkeyNames;
+		for (size_t i = 0; i < config.threadDumpHotkey.size(); ++i) {
+			if (i > 0) {
+				hotkeyNames += "+";
+			}
+			int vk = config.threadDumpHotkey[i];
+			if (vk == VK_CONTROL || vk == 17) {
+				hotkeyNames += "Ctrl";
+			} else if (vk == VK_SHIFT || vk == 16) {
+				hotkeyNames += "Shift";
+			} else if (vk == VK_MENU || vk == 18) {
+				hotkeyNames += "Alt";
+			} else if (vk >= VK_F1 && vk <= VK_F24) {
+				hotkeyNames += std::format("F{}", vk - VK_F1 + 1);
+			} else if (vk >= 'A' && vk <= 'Z') {
+				hotkeyNames += static_cast<char>(vk);
+			} else if (vk >= '0' && vk <= '9') {
+				hotkeyNames += static_cast<char>(vk);
+			} else {
+				hotkeyNames += std::to_string(vk);
+			}
+		}
+		logger::info("Thread dump hotkey monitoring started ({})", hotkeyNames);
 	}
 
 	void StopHotkeyMonitoring()

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -58,7 +58,7 @@ void Settings::Debug::Load(CSimpleIniA& a_ini)
 	get_value(a_ini, enableThreadDumpHotkey, section, "Enable Thread Dump Hotkey", ";Enable thread dump hotkey for diagnosing hangs/deadlocks. Default: true\n;When enabled, press Ctrl+Shift+F12 while game is frozen to generate dump.\n;Set to 0 to disable (no monitoring thread will be created).");
 
 	// Parse hotkey combination (comma-separated list of VK codes)
-	std::string hotkeyStr;
+	std::string hotkeyStr{ "17, 16, 123" };
 	get_value(a_ini, hotkeyStr, section, "Thread Dump Hotkey", ";Hotkey combination (VK codes): Ctrl=17, Shift=16, F12=123. Default: 17, 16, 123\n;VK code reference: https://learn.microsoft.com/en-us/windows/win32/inputdev/virtual-key-codes");
 
 	// Heap analysis section header

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -141,7 +141,7 @@ void Settings::Debug::Load(CSimpleIniA& a_ini)
 	get_value(a_ini, flushLevel, section, "Flush Level", ";Log level to force messages to print from buffer. Default: 0");
 	get_value(a_ini, waitForDebugger, section, "Wait for Debugger for Crash", ";Enable if using VisualStudio to debug CrashLogger itself. Default: false\n;Set false otherwise because Crashlogger will not produce a crash until the debugger is detected.");
 
-	threadDumpHotkey.clear();
+	std::vector<int> parsedHotkey;
 	if (!hotkeyStr.empty()) {
 		std::istringstream iss(hotkeyStr);
 		std::string token;
@@ -151,12 +151,15 @@ void Settings::Debug::Load(CSimpleIniA& a_ini)
 			token.erase(token.find_last_not_of(" \t") + 1);
 			if (!token.empty()) {
 				try {
-					threadDumpHotkey.push_back(std::stoi(token));
+					parsedHotkey.push_back(std::stoi(token));
 				} catch (...) {
 					// Skip invalid values
 				}
 			}
 		}
+	}
+	if (!parsedHotkey.empty()) {
+		threadDumpHotkey = std::move(parsedHotkey);
 	}
 }
 

--- a/src/Settings.h
+++ b/src/Settings.h
@@ -46,8 +46,10 @@ private:
 	{
 		try {
 			ini::get_value(a_ini, a_value, a_section, a_key, a_comment);
+		} catch (const std::exception& e) {
+			logger::warn("Failed to parse setting [{}] {} (Error: {})", a_section, a_key, e.what());
 		} catch (...) {
-			// Keep the default/existing value on parsing failure
+			logger::warn("Failed to parse setting [{}] {} (Unknown error)", a_section, a_key);
 		}
 	}
 	Debug debug{};

--- a/src/Settings.h
+++ b/src/Settings.h
@@ -44,7 +44,11 @@ private:
 	template <class T>
 	static void get_value(CSimpleIniA& a_ini, T& a_value, const char* a_section, const char* a_key, const char* a_comment)
 	{
-		ini::get_value(a_ini, a_value, a_section, a_key, a_comment);
+		try {
+			ini::get_value(a_ini, a_value, a_section, a_key, a_comment);
+		} catch (...) {
+			// Keep the default/existing value on parsing failure
+		}
 	}
 	Debug debug{};
 };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed default thread dump hotkey configuration to Ctrl+Shift+F12
  * Improved error handling when loading configuration files to prevent crashes from invalid settings
  * Enhanced hotkey logging to display human-readable hotkey names instead of hardcoded values

<!-- end of auto-generated comment: release notes by coderabbit.ai -->