### PR TITLE
feat(handler): log __fastfail and fail-fast exceptions via VEH

### DIFF
--- a/src/Crash/CrashHandler.cpp
+++ b/src/Crash/CrashHandler.cpp
@@ -1786,15 +1786,8 @@ next_label:;
 			// overwriting SetUnhandledExceptionFilter).
 			::SetUnhandledExceptionFilter(reinterpret_cast<::LPTOP_LEVEL_EXCEPTION_FILTER>(&UnhandledExceptions));
 
-			// __fastfail / fail-fast (int 29h) and /GS stack-cookie failures terminate the
-			// process WITHOUT invoking the top-level UnhandledExceptionFilter, so our normal
-			// logging path never runs -- WER pops a JIT-debugger modal instead and no crash
-			// log is written. The vectored handler still receives them at first chance, and
-			// these codes are always terminal (never handled-and-continued), so drive the full
-			// logger from here while the context is intact. UnhandledExceptions ends in
-			// TerminateProcess, so it never returns. The guard prevents re-entry if logging
-			// itself trips a fast-fail. (Also catches CRT abort()/std::terminate, which
-			// __fastfail with STATUS_STACK_BUFFER_OVERRUN.)
+			// __fastfail and /GS-cookie failures bypass SetUnhandledExceptionFilter; VEH catches them.
+			// Guard prevents re-entry if logging itself trips a fast-fail.
 			if (a_exception && a_exception->ExceptionRecord) {
 				switch (a_exception->ExceptionRecord->ExceptionCode) {
 				case 0xC0000409:  // STATUS_STACK_BUFFER_OVERRUN (__fastfail, /GS, abort)

--- a/src/Crash/CrashHandler.cpp
+++ b/src/Crash/CrashHandler.cpp
@@ -13,6 +13,7 @@
 #include <Settings.h>
 #include <TlHelp32.h>
 #include <Zydis/Zydis.h>
+#include <atomic>
 #include <iomanip>
 #include <magic_enum/magic_enum.hpp>
 #include <openvr.h>
@@ -1779,9 +1780,37 @@ next_label:;
 			return EXCEPTION_CONTINUE_SEARCH;
 		}
 
-		std::int32_t _stdcall VectoredExceptions(::EXCEPTION_POINTERS*) noexcept
+		std::int32_t _stdcall VectoredExceptions(::EXCEPTION_POINTERS* a_exception) noexcept
 		{
+			// Keep our top-level filter installed (defends against other plugins / ENB
+			// overwriting SetUnhandledExceptionFilter).
 			::SetUnhandledExceptionFilter(reinterpret_cast<::LPTOP_LEVEL_EXCEPTION_FILTER>(&UnhandledExceptions));
+
+			// __fastfail / fail-fast (int 29h) and /GS stack-cookie failures terminate the
+			// process WITHOUT invoking the top-level UnhandledExceptionFilter, so our normal
+			// logging path never runs -- WER pops a JIT-debugger modal instead and no crash
+			// log is written. The vectored handler still receives them at first chance, and
+			// these codes are always terminal (never handled-and-continued), so drive the full
+			// logger from here while the context is intact. UnhandledExceptions ends in
+			// TerminateProcess, so it never returns. The guard prevents re-entry if logging
+			// itself trips a fast-fail. (Also catches CRT abort()/std::terminate, which
+			// __fastfail with STATUS_STACK_BUFFER_OVERRUN.)
+			if (a_exception && a_exception->ExceptionRecord) {
+				switch (a_exception->ExceptionRecord->ExceptionCode) {
+				case 0xC0000409:  // STATUS_STACK_BUFFER_OVERRUN (__fastfail, /GS, abort)
+				case 0xC0000602:  // STATUS_FAIL_FAST_EXCEPTION
+					{
+						static std::atomic_bool handling{ false };
+						bool expected = false;
+						if (handling.compare_exchange_strong(expected, true)) {
+							UnhandledExceptions(a_exception);  // logs + TerminateProcess; never returns
+						}
+						break;
+					}
+				default:
+					break;
+				}
+			}
 			return EXCEPTION_CONTINUE_SEARCH;
 		}
 	}  // namespace


### PR DESCRIPTION
## Summary

- `STATUS_STACK_BUFFER_OVERRUN` (0xC0000409) and `STATUS_FAIL_FAST_EXCEPTION` (0xC0000602) bypass `SetUnhandledExceptionFilter` and terminate the process without invoking the top-level handler — crash logs were never written for `/GS` stack-cookie failures, `__fastfail()`, `abort()`, and `std::terminate()`
- The vectored handler still receives these codes at first chance; since they are always terminal, this routes them through `UnhandledExceptions` (logs + `TerminateProcess`) while the exception context is still intact
- An `atomic_bool` re-entry guard prevents a recursive fast-fail during logging from causing a double-fault

## Test plan

- [ ] Build passes all presets (SE/AE/VR/flat)
- [ ] Trigger a `/GS` stack-cookie failure or call `__fastfail(0)` from a test plugin and verify a crash log is generated
- [ ] Verify no crash log regression for normal `EXCEPTION_ACCESS_VIOLATION` crashes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01CuM742GiWFKuK1c7DgwYTi

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved crash handling so certain abrupt termination scenarios are captured in crash reports instead of being lost.
  * Added safeguards to prevent duplicate crash logging during repeated failure events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->