### PR TITLE
fix(handler): catch STATUS_HEAP_CORRUPTION via the fastfail VEH path

### DIFF
--- a/src/Crash/CrashHandler.cpp
+++ b/src/Crash/CrashHandler.cpp
@@ -1792,6 +1792,7 @@ next_label:;
 				switch (a_exception->ExceptionRecord->ExceptionCode) {
 				case 0xC0000409:  // STATUS_STACK_BUFFER_OVERRUN (__fastfail, /GS, abort)
 				case 0xC0000602:  // STATUS_FAIL_FAST_EXCEPTION
+				case 0xC0000374:  // STATUS_HEAP_CORRUPTION (RtlReportFatalFailure, same fastfail path)
 					{
 						static std::atomic_bool handling{ false };
 						bool expected = false;


### PR DESCRIPTION
## Summary
- Heap corruption detected by Windows' heap manager terminates the process via `RtlReportFatalFailure` -- the same fastfail mechanism as `STATUS_STACK_BUFFER_OVERRUN`/`STATUS_FAIL_FAST_EXCEPTION`, which already bypasses `SetUnhandledExceptionFilter` and is only visible through the VEH installed in PR #37.
- `STATUS_HEAP_CORRUPTION` (`0xC0000374`) wasn't in that switch, so a heap-corruption crash would silently miss CrashLogger's log entirely -- exactly the "Windows Error Reporting caught it, CrashLogger didn't" class of gap.

## Changes
- Add `0xC0000374` to the fastfail-style switch in `VectoredExceptions`, same interception pattern as the existing two codes.

## Test plan
- [x] Follows the existing, already-shipped fastfail-interception pattern (PR #37) exactly -- same guard, same call path.