### PR TITLE
build(vcpkg): correct license to GPL-3.0-or-later

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -5,7 +5,7 @@
   "port-version": 0,
   "description": "SKSE/SKSEVR plugin that generates crash logs when the game Just Works™.",
   "homepage": "https://github.com/alandtse/CrashLoggerSSE",
-  "license": "MIT",
+  "license": "GPL-3.0-or-later",
   "features": {
     "plugin": {
       "description": "Build the SKSE plugin.",


### PR DESCRIPTION
## Summary
- `vcpkg.json`'s `license` field still said `"MIT"` -- left over from before this repo relicensed to GPL-3.0-or-later with a modding exception. `COPYING`, `EXCEPTIONS.md`, and the README's License section already reflect the real license; this manifest field just never got updated to match.

## Context
Found while using this repo as the reference example for [alandtse/CommonLibVR#238](https://github.com/alandtse/CommonLibVR/pull/238), CommonLibVR's own relicense PR. That PR copies this repo's `COPYING`/`EXCEPTIONS.md` verbatim, but deliberately did *not* copy this same stale `"MIT"` value into CommonLibVR's `vcpkg.json` -- worth fixing at the source too.

## Test plan
- [ ] Manifest-only change, no build/CI impact expected.