### PR TITLE
feat: support Skyrim AE 1.7.99

### DIFF
--- a/src/Crash/Introspection/Introspection.cpp
+++ b/src/Crash/Introspection/Introspection.cpp
@@ -86,7 +86,7 @@ namespace Crash::Introspection::SSE
 				std::string handleString;
 				if (a_skyrimVm) {
 					RE::BSFixedString handle;
-					a_skyrimVm->handlePolicy.ConvertHandleToString(obj->GetHandle(), handle);
+					a_skyrimVm->GetHandlePolicy().ConvertHandleToString(obj->GetHandle(), handle);
 					if (handle.c_str() && handle[0]) {
 						handleString = handle.c_str();
 					}
@@ -2055,7 +2055,7 @@ namespace Crash::Introspection::SSE
 			const void* a_ptr, int tab_depth = 0) noexcept
 		{
 			const auto object = static_cast<const value_type*>(a_ptr);
-			const auto& handlePolicy = RE::SkyrimVM::GetSingleton()->handlePolicy;
+			const auto& handlePolicy = RE::SkyrimVM::GetSingleton()->GetHandlePolicy();
 			const auto datahandler = RE::TESDataHandler::GetSingleton();
 			try {
 				auto currentStackFrame = object->stack->top;  // get stack from BSScript::Internal::CodeTasklet (or get stack directly if it's a stack object

--- a/src/Crash/Modules/ModuleHandler.cpp
+++ b/src/Crash/Modules/ModuleHandler.cpp
@@ -180,7 +180,7 @@ namespace Crash::Modules
 			}
 
 		private:
-			REL::IDDatabase::Offset2ID _offset2ID{ std::execution::par_unseq };
+			REL::Offset2ID _offset2ID;
 		};
 
 		class Factory


### PR DESCRIPTION
## Summary
- Bumps the CommonLibSSE-NG submodule to CommonLibVR-ng `v6.4.0`, which adds support for AE 1.7.99's new address-library format and fixes the `Module` runtime classifier that silently misclassified 1.7.99 as SE.
- Fixes two call sites in `CodeTasklet` introspection that read `SkyrimVM::handlePolicy` directly -- that field is now version-gated in CommonLibVR-ng (AE 1.7.99 shifts it and everything after it by 0x10 bytes due to 2 new vtable slots), so direct field access silently read the wrong memory on a real 1.7.99 install.

## Test plan
- [x] `cmake --preset Release-MSVC && cmake --build build\release-msvc` -- clean build
- [x] Deployed to a real 1.7.99 install (both SE and VR `Data/SKSE/Plugins`); loads and logs successfully

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_013WqQD3vawqgNMZ4tAR3bSA