### PR TITLE
build(scripts): package PDBs as a single FOMOD archive

### DIFF
--- a/scripts/package_skyrim_pdbs.py
+++ b/scripts/package_skyrim_pdbs.py
@@ -1,26 +1,44 @@
 #!/usr/bin/env python3
 """
-Package the Ghidra-generated Skyrim runtime PDBs as Nexus optional-file archives
-for CrashLogger (https://www.nexusmods.com/skyrimspecialedition/mods/59818).
+Package the Ghidra-generated Skyrim runtime PDBs as a single FOMOD-wrapped
+archive for CrashLogger (https://www.nexusmods.com/skyrimspecialedition/mods/59818).
 
 CrashLogger resolves vanilla SkyrimSE.exe / SkyrimVR.exe call-stack frames by name
 using these PDBs. DIA (PdbHandler.cpp -> loadDataForExe(filename, sPluginPath)) finds
 the PDB in Data/SKSE/Plugins/ and validates it against the binary by GUID/age, so the
-in-archive file is always named after the runtime's exe (both flat SE+AE ship as
+in-archive file is always named after the runtime's exe (SE/AE/SE-1.7.99 all ship as
 SkyrimSE.pdb; only one Skyrim version is installed at a time, GUID picks the right one).
+
+Rather than shipping 4 separate archives and making the player pick the right one by
+hand, this builds ONE archive with a FOMOD installer: a single install step offers all
+4 runtime PDBs as mutually-exclusive options, gameDependency-conditioned on the
+installed Skyrim version so the mod manager pre-selects the matching one automatically
+-- same mechanism as our sister repo open-shaders uses for its shader-cache picker
+(.github/scripts/build-fomod-package.py), and same reasoning: gameDependency has no
+comparison operator or negation, only "installed game version >= X", so each option's
+pattern list checks every runtime's threshold ordered highest-to-lowest game_version
+first so the first (most specific) match wins, rather than a lower threshold also
+matching and overriding it. RUNTIMES below must stay ordered highest game_version first
+for this to hold; a runtime on a wholly different game (VR) still composes correctly
+here since its threshold (1.4.15) is numerically lower than every SE/AE threshold, so an
+SE/AE install always intercepts before ever reaching VR's pattern, and a VR install
+(never >= 1.5.97) falls through to VR's own pattern.
 
 Per runtime:
   1. locate the freshest source PDB (Ghidra/pdbgen output),
   2. stage it under SKSE/Plugins/<consumer-name>.pdb (mod-manager-relative),
-  3. 7z it to an archive named for the Nexus display name.
+  3. build FOMOD XML via pyfomod,
+  4. 7z the whole staged tree into one archive.
 
-Output archives go to <out>/ (default: ./pdb_artifacts). Upload them manually to the
-mod's Optional Files; the Nexus version is the date (YYYY.MM.DD).
+Output archive goes to <out>/ (default: ./pdb_artifacts). Upload it manually to the
+mod's files; the Nexus version is the date (YYYY.MM.DD).
 
 NOTE: regenerating the PDBs from Ghidra (to capture the latest RE) is a separate step
 run inside the open Ghidra session (PdbGen script per program), since it needs the live,
 analyzed project. This script packages whatever PDBs are currently on disk; pass
 --require-fresh <days> to refuse stale PDBs so you don't ship an outdated symbol set.
+
+Requires: pip install pyfomod
 """
 
 import argparse
@@ -30,37 +48,70 @@ import shutil
 import subprocess
 import sys
 
+import pyfomod
+
 # Default 7-Zip location on Windows; override with --sevenzip.
 DEFAULT_7Z = r"C:\Program Files\7-Zip\7z.exe"
 
 # Runtime table. Edit paths here if a game install moves.
-#   key            : short id used on the CLI (--runtimes se ae vr)
+#   key            : short id used on the CLI (--runtimes se ae se17 vr)
 #   src_pdb        : where Ghidra/pdbgen writes this runtime's PDB
 #   consumer_name  : filename DIA looks for inside Data/SKSE/Plugins/ (the exe's basename + .pdb)
-#   nexus_name     : Nexus optional-file display name (archive is named to match)
+#   display_name   : shown in the FOMOD option list and used in the version string
+#   game_version   : gameDependency threshold -- MUST stay ordered highest-to-lowest below
+#                    (see module docstring for why)
 # IMPORTANT: PdbGen writes the .pdb next to each program's IMPORT path, which is the
 # game ROOT dir (where the .exe lives), NOT Data/SKSE/Plugins/. The Plugins copies are
 # the previously-deployed PDBs and go stale; always source from the root (PdbGen output).
+#
+# Each runtime is imported into Ghidra from its own distinctly-named exe copy so its
+# PdbGen output doesn't collide with another runtime's -- except 1.5.97, which is always
+# SkyrimSE.pdb (unsuffixed): that's the plain SkyrimSE.exe import. If the wrong build is
+# behind that path when this runs, that's a Ghidra-side problem to fix before packaging,
+# not something this script tries to detect -- it only checks whether the file exists.
 RUNTIMES = {
-    "se": {
-        "src_pdb": r"E:\SteamLibrary\steamapps\common\Skyrim Special Edition\SkyrimSE.pdb",
+    "se17": {
+        "src_pdb": r"E:\SteamLibrary\steamapps\common\Skyrim Special Edition\SkyrimSE.1.7.99.pdb",
         "consumer_name": "SkyrimSE.pdb",
-        "nexus_name": "SkyrimSE 1.5.97.0",
+        "display_name": "SkyrimSE 1.7.99.0",
+        "game_version": "1.7.99",
     },
     "ae": {
         # AE imports from SkyrimSE.1170.exe -> PdbGen writes SkyrimSE.1170.pdb in the game root.
         "src_pdb": r"E:\SteamLibrary\steamapps\common\Skyrim Special Edition\SkyrimSE.1170.pdb",
         "consumer_name": "SkyrimSE.pdb",  # same as SE: both runtimes execute SkyrimSE.exe; GUID disambiguates
-        "nexus_name": "SkyrimSE 1.6.1170.0",
+        "display_name": "SkyrimSE 1.6.1170.0",
+        "game_version": "1.6.1170",
+    },
+    "se": {
+        # Always the unsuffixed SkyrimSE.pdb -- the plain SkyrimSE.exe import.
+        "src_pdb": r"E:\SteamLibrary\steamapps\common\Skyrim Special Edition\SkyrimSE.pdb",
+        "consumer_name": "SkyrimSE.pdb",
+        "display_name": "SkyrimSE 1.5.97.0",
+        "game_version": "1.5.97",
     },
     "vr": {
         "src_pdb": r"E:\SteamLibrary\steamapps\common\SkyrimVR\SkyrimVR.pdb",
         "consumer_name": "SkyrimVR.pdb",
-        "nexus_name": "SkyrimVR PDB",
+        "display_name": "SkyrimVR 1.4.15.0",
+        "game_version": "1.4.15",
     },
 }
 
-PLUGINS_REL = os.path.join("SKSE", "Plugins")  # mod-manager-relative install path
+PLUGINS_REL = os.path.join("SKSE", "Plugins")  # local filesystem staging path (OS-native separators)
+PLUGINS_REL_POSIX = "SKSE/Plugins"  # FOMOD source/destination strings always use forward slashes
+
+MOD_NAME = "CrashLogger PDBs"
+MOD_AUTHOR = "CrashLogger Contributors"
+MOD_DESCRIPTION = (
+    "Optional PDB symbol files for CrashLogger, letting it resolve vanilla "
+    "SkyrimSE.exe/SkyrimVR.exe call-stack frames by name instead of +offset. "
+    "Pick the variant matching your installed game version; the mod manager "
+    "pre-selects it automatically where it can detect your game version."
+)
+MOD_WEBSITE = "https://www.nexusmods.com/skyrimspecialedition/mods/59818"
+STEP_PAGE_NAME = "Runtime PDB"
+STEP_GROUP_NAME = "Symbol file for your installed Skyrim version"
 
 
 def human_size(n):
@@ -77,10 +128,10 @@ def find_7z(explicit):
     sys.exit("error: 7z not found. Install 7-Zip or pass --sevenzip <path>.")
 
 
-def package_runtime(key, cfg, out_dir, sevenzip, require_fresh):
+def stage_runtime(key, cfg, stage_dir, require_fresh):
     src = cfg["src_pdb"]
     if not os.path.isfile(src):
-        return (key, False, f"source PDB missing: {src}")
+        return (key, False, f"source PDB missing: {src}", None)
 
     mtime = os.path.getmtime(src)
     age_days = (datetime.datetime.now().timestamp() - mtime) / 86400.0
@@ -88,33 +139,65 @@ def package_runtime(key, cfg, out_dir, sevenzip, require_fresh):
     if require_fresh is not None and age_days > require_fresh:
         return (key, False,
                 f"PDB is {age_days:.1f} days old (> --require-fresh {require_fresh}); "
-                f"regenerate in Ghidra first. {src}")
+                f"regenerate in Ghidra first. {src}", None)
 
-    # Stage: out/<key>/SKSE/Plugins/<consumer_name>.pdb
-    stage = os.path.join(out_dir, key)
-    plugin_dir = os.path.join(stage, PLUGINS_REL)
-    if os.path.isdir(stage):
-        shutil.rmtree(stage)
+    plugin_dir = os.path.join(stage_dir, PLUGINS_REL)
     os.makedirs(plugin_dir, exist_ok=True)
     staged_pdb = os.path.join(plugin_dir, cfg["consumer_name"])
     shutil.copy2(src, staged_pdb)
 
-    # Archive: out/<nexus_name>.7z containing SKSE/Plugins/<consumer_name>.pdb
-    archive = os.path.join(out_dir, cfg["nexus_name"] + ".7z")
-    if os.path.isfile(archive):
-        os.remove(archive)
-    # add from the stage root so the archive contains SKSE/Plugins/... (no extra leading dir)
-    proc = subprocess.run(
-        [sevenzip, "a", "-t7z", "-mx=9", archive, PLUGINS_REL],
-        cwd=stage, capture_output=True, text=True)
-    if proc.returncode != 0:
-        return (key, False, f"7z failed: {proc.stdout}\n{proc.stderr}")
-
-    asize = os.path.getsize(archive)
+    asize = os.path.getsize(staged_pdb)
     return (key, True,
-            f"{cfg['nexus_name']}.7z  ({human_size(asize)})  "
-            f"<- {cfg['consumer_name']} from {gen_date:%Y-%m-%d %H:%M} "
-            f"(version: {gen_date:%Y.%m.%d})")
+            f"{cfg['display_name']}  ({human_size(asize)})  "
+            f"<- {os.path.basename(src)} from {gen_date:%Y-%m-%d %H:%M}", gen_date)
+
+
+def build_root(version, available):
+    """available: list of (key, cfg) in RUNTIMES iteration order (highest game_version first)."""
+    root = pyfomod.Root()
+    root.name = f"{MOD_NAME} {version}"
+    root.author = MOD_AUTHOR
+    root.version = version
+    root.description = MOD_DESCRIPTION
+    root.website = MOD_WEBSITE
+
+    if not available:
+        return root
+
+    page = pyfomod.Page()
+    page.name = STEP_PAGE_NAME
+
+    group = pyfomod.Group()
+    group.name = STEP_GROUP_NAME
+    # ATMOSTONE (not EXACTLYONE): skipping is valid -- these are optional symbol files,
+    # CrashLogger works fine (just less readable stack traces) without any of them.
+    group.type = pyfomod.GroupType.ATMOSTONE
+
+    for key, cfg in available:
+        option = pyfomod.Option()
+        option.name = cfg["display_name"]
+        option.description = f"Symbols for {cfg['display_name']}."
+        option.files[f"{key}/{PLUGINS_REL_POSIX}/"] = PLUGINS_REL_POSIX
+
+        option_type = pyfomod.Type()
+        option_type.default = pyfomod.OptionType.OPTIONAL
+        # All available runtimes, not just this one: each pattern is a single
+        # gameDependency threshold, evaluated top-to-bottom by the mod manager --
+        # first match wins. Listing them highest-game_version-first here (mirroring
+        # RUNTIMES' own order) means a higher runtime's threshold always intercepts
+        # before a lower one's, so only the actual best match ends up Recommended.
+        for other_key, other_cfg in available:
+            conditions = pyfomod.Conditions()
+            conditions[None] = other_cfg["game_version"]
+            is_self = other_key == key
+            option_type[conditions] = pyfomod.OptionType.RECOMMENDED if is_self else pyfomod.OptionType.OPTIONAL
+        option.type = option_type
+
+        group.append(option)
+
+    page.append(group)
+    root.pages.append(page)
+    return root
 
 
 def parse_args():
@@ -122,39 +205,74 @@ def parse_args():
                                 formatter_class=argparse.RawDescriptionHelpFormatter)
     p.add_argument("--runtimes", nargs="+", default=list(RUNTIMES.keys()),
                    choices=list(RUNTIMES.keys()),
-                   help="which runtimes to package (default: all)")
+                   help="which runtimes to include (default: all)")
     p.add_argument("--out", default=os.path.join(os.getcwd(), "pdb_artifacts"),
-                   help="output directory for the .7z archives")
+                   help="output directory for the staged tree and archive")
     p.add_argument("--sevenzip", default=None, help="path to 7z.exe")
     p.add_argument("--require-fresh", type=float, default=None, metavar="DAYS",
                    help="fail if any source PDB is older than DAYS (guards against shipping stale symbols)")
+    p.add_argument("--version", default=None,
+                   help="FOMOD version string (default: today's date, YYYY.MM.DD)")
     return p.parse_args()
 
 
 def main():
     args = parse_args()
     sevenzip = find_7z(args.sevenzip)
-    # Absolute-ize: package_runtime runs 7z with cwd=<stage>, so a relative archive path would be
-    # resolved against the stage dir (nested) and the later getsize would miss it.
     args.out = os.path.abspath(args.out)
-    os.makedirs(args.out, exist_ok=True)
+    version = args.version or datetime.date.today().strftime("%Y.%m.%d")
 
-    print(f"Packaging Skyrim PDBs -> {args.out}")
+    stage_root = os.path.join(args.out, "staged")
+    if os.path.isdir(stage_root):
+        shutil.rmtree(stage_root)
+    os.makedirs(stage_root, exist_ok=True)
+
+    print(f"Staging Skyrim PDBs -> {stage_root}")
     print(f"Using 7z: {sevenzip}\n")
 
-    results = [package_runtime(k, RUNTIMES[k], args.out, sevenzip, args.require_fresh)
-               for k in args.runtimes]
+    # Preserve RUNTIMES' declared order (highest game_version first) -- required for
+    # the gameDependency interception logic in build_root().
+    ordered_keys = [k for k in RUNTIMES if k in args.runtimes]
+    results = [stage_runtime(k, RUNTIMES[k], os.path.join(stage_root, k), args.require_fresh)
+               for k in ordered_keys]
 
     ok = [r for r in results if r[1]]
     bad = [r for r in results if not r[1]]
-    for key, success, msg in results:
+    for key, success, msg, _ in results:
         print(f"  [{'OK ' if success else 'FAIL'}] {key}: {msg}")
 
-    print(f"\n{len(ok)}/{len(results)} archives built in {args.out}")
-    if ok:
-        print("Upload these to the mod's Optional Files (version = date shown above):")
-        for key, _, _ in ok:
-            print(f"    {RUNTIMES[key]['nexus_name']}.7z")
+    if not ok:
+        print("\nno runtimes staged; nothing to package.")
+        sys.exit(1)
+
+    available = [(key, RUNTIMES[key]) for key, success, _, _ in results if success]
+    root = build_root(version, available)
+    errors = root.validate()
+    if errors:
+        print("error: generated ModuleConfig.xml failed validation:", file=sys.stderr)
+        for error in errors:
+            print(f"  {error}", file=sys.stderr)
+        sys.exit(1)
+
+    pyfomod.write(root, stage_root)
+
+    archive_name = f"CrashLogger-PDBs-{version}.zip"
+    archive = os.path.join(args.out, archive_name)
+    if os.path.isfile(archive):
+        os.remove(archive)
+    proc = subprocess.run(
+        [sevenzip, "a", "-tzip", "-mx=9", archive, "."],
+        cwd=stage_root, capture_output=True, text=True)
+    if proc.returncode != 0:
+        print(f"error: 7z failed: {proc.stdout}\n{proc.stderr}", file=sys.stderr)
+        sys.exit(1)
+
+    asize = os.path.getsize(archive)
+    print(f"\n{len(ok)}/{len(results)} runtime(s) packaged into {archive_name} ({human_size(asize)})")
+    if bad:
+        print("Missing/stale runtimes were skipped (see FAIL lines above); "
+              "regenerate them in Ghidra and re-run to include them.")
+    print(f"\nUpload {archive} to the mod's files (version: {version}).")
     if bad:
         sys.exit(1)
 

--- a/scripts/package_skyrim_pdbs.py
+++ b/scripts/package_skyrim_pdbs.py
@@ -109,6 +109,15 @@ MOD_DESCRIPTION = (
 )
 NEXUS_MOD_ID = "59818"  # CrashLogger's mod page
 MOD_WEBSITE = f"https://www.nexusmods.com/skyrimspecialedition/mods/{NEXUS_MOD_ID}"
+
+# Matches the "Skyrim PDBs" file entry (file_id 794129) created manually on the mod page --
+# keep these in sync with whatever's set there so automated uploads look like a continuation
+# of that entry, not a different file.
+NEXUS_FILE_ID = "794129"
+NEXUS_FILE_DISPLAY_NAME = "Skyrim PDBs"
+NEXUS_FILE_DESCRIPTION = (
+    "This is a reverse engineered PDB to help identify game addresses. This is a fomod all-in-one."
+)
 STEP_PAGE_NAME = "Runtime PDB"
 STEP_GROUP_NAME = "Symbol file for your installed Skyrim version"
 
@@ -200,9 +209,9 @@ def build_root(version, available):
 NEXUS_API_BASE = "https://api.nexusmods.com/v3"
 
 
-def upload_to_nexus(archive_path, file_id, api_key, version, display_name,
+def upload_to_nexus(archive_path, file_id, api_key, version, display_name, description,
                      mod_id=None, changelog=None, category="optional",
-                     archive_existing=False):
+                     archive_existing=True):
     """Push archive_path to Nexus as a new version of file_id via the public v3 API --
     the same multipart-upload + finalise + create-version flow as Nexus-Mods/upload-action,
     reimplemented directly so it runs on the Ghidra machine without a CI dependency."""
@@ -257,6 +266,7 @@ def upload_to_nexus(archive_path, file_id, api_key, version, display_name,
     version_resp = session.post(f"{NEXUS_API_BASE}/mod-files/{file_id}/versions", json={
         "upload_id": upload_id,
         "name": display_name,
+        "description": description,
         "version": version,
         "file_category": category,
         "archive_existing_file": archive_existing,
@@ -290,13 +300,20 @@ def parse_args():
     p.add_argument("--regenerate", action="store_true",
                    help="regenerate PDBs in the open Ghidra session first (via regenerate_pdbs.py/GhidrAssistMCP)")
     p.add_argument("--upload", action="store_true",
-                   help="upload the built archive to Nexus as a new file version (requires --nexus-file-id)")
-    p.add_argument("--nexus-file-id", default=None,
-                   help="Nexus file_id to add a version to (must already exist -- create it once via the website)")
+                   help="upload the built archive to Nexus as a new file version")
+    p.add_argument("--nexus-file-id", default=NEXUS_FILE_ID,
+                   help="Nexus file_id to add a version to (default: the 'Skyrim PDBs' entry, "
+                        f"{NEXUS_FILE_ID}); must already exist -- create it once via the website")
     p.add_argument("--nexus-api-key", default=os.environ.get("NEXUS_API_KEY"),
                    help="Nexus API key (default: $NEXUS_API_KEY)")
     p.add_argument("--nexus-mod-id", default=NEXUS_MOD_ID, help="Nexus mod_id, for --changelog")
     p.add_argument("--nexus-category", default="optional", help="Nexus file_category for the upload")
+    p.add_argument("--nexus-display-name", default=NEXUS_FILE_DISPLAY_NAME,
+                   help="Nexus-facing file display name")
+    p.add_argument("--description", default=NEXUS_FILE_DESCRIPTION,
+                   help="Nexus file description")
+    p.add_argument("--archive-existing", action=argparse.BooleanOptionalAction, default=True,
+                   help="move the file's current version to Old Files when uploading a new one (default: on)")
     p.add_argument("--changelog", default=None, help="changelog text to attach (requires --nexus-mod-id)")
     return p.parse_args()
 
@@ -377,8 +394,9 @@ def main():
             sys.exit("error: refusing to upload an archive missing runtimes -- fix the FAIL lines above first")
         print(f"\nUploading to Nexus file {args.nexus_file_id} (mod {args.nexus_mod_id})...")
         upload_to_nexus(archive, args.nexus_file_id, args.nexus_api_key, version,
-                         display_name=archive_name, mod_id=args.nexus_mod_id,
-                         changelog=args.changelog, category=args.nexus_category)
+                         display_name=args.nexus_display_name, description=args.description,
+                         mod_id=args.nexus_mod_id, changelog=args.changelog,
+                         category=args.nexus_category, archive_existing=args.archive_existing)
         print("Uploaded.")
     else:
         print(f"\nUpload {archive} to the mod's files (version: {version}), "

--- a/scripts/package_skyrim_pdbs.py
+++ b/scripts/package_skyrim_pdbs.py
@@ -35,12 +35,16 @@ Pass --upload --nexus-file-id <id> to push the built archive straight to Nexus a
 file version (Nexus's public v3 API, no CI involved) instead of uploading it by hand.
 The target file_id must already exist on the mod page -- Nexus's API can only add a
 version to an existing file entry, not create a new one; create it once via the website.
+--upload skips the actual upload (but still builds the archive) if the staged PDBs'
+content hash matches the last successful upload -- pass --force-upload to upload anyway.
 
 Requires: pip install pyfomod requests
 """
 
 import argparse
 import datetime
+import hashlib
+import json
 import os
 import shutil
 import subprocess
@@ -52,6 +56,32 @@ import requests
 
 # Default 7-Zip location on Windows; override with --sevenzip.
 DEFAULT_7Z = r"C:\Program Files\7-Zip\7z.exe"
+
+# Shared pipeline state (per-runtime Ghidra modification numbers, last-uploaded content
+# fingerprint) -- lives under the already-gitignored pdb_artifacts/.
+STATE_FILE = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "pdb_artifacts", ".pdbgen_state.json")
+
+
+def load_state():
+    try:
+        with open(STATE_FILE) as f:
+            return json.load(f)
+    except (FileNotFoundError, json.JSONDecodeError):
+        return {"runtimes": {}, "last_upload": {}}
+
+
+def save_state(state):
+    os.makedirs(os.path.dirname(STATE_FILE), exist_ok=True)
+    with open(STATE_FILE, "w") as f:
+        json.dump(state, f, indent=2)
+
+
+def sha256_of(path):
+    digest = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(1 << 20), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
 
 # Runtime table. Edit paths here if a game install moves.
 #   key            : short id used on the CLI (--runtimes se ae ae17 vr)
@@ -139,7 +169,7 @@ def find_7z(explicit):
 def stage_runtime(key, cfg, stage_dir, require_fresh):
     src = cfg["src_pdb"]
     if not os.path.isfile(src):
-        return (key, False, f"source PDB missing: {src}", None)
+        return (key, False, f"source PDB missing: {src}", None, None)
 
     mtime = os.path.getmtime(src)
     age_days = (datetime.datetime.now().timestamp() - mtime) / 86400.0
@@ -147,7 +177,7 @@ def stage_runtime(key, cfg, stage_dir, require_fresh):
     if require_fresh is not None and age_days > require_fresh:
         return (key, False,
                 f"PDB is {age_days:.1f} days old (> --require-fresh {require_fresh}); "
-                f"regenerate in Ghidra first. {src}", None)
+                f"regenerate in Ghidra first. {src}", None, None)
 
     plugin_dir = os.path.join(stage_dir, PLUGINS_REL)
     os.makedirs(plugin_dir, exist_ok=True)
@@ -157,7 +187,7 @@ def stage_runtime(key, cfg, stage_dir, require_fresh):
     asize = os.path.getsize(staged_pdb)
     return (key, True,
             f"{cfg['display_name']}  ({human_size(asize)})  "
-            f"<- {os.path.basename(src)} from {gen_date:%Y-%m-%d %H:%M}", gen_date)
+            f"<- {os.path.basename(src)} from {gen_date:%Y-%m-%d %H:%M}", gen_date, sha256_of(src))
 
 
 def build_root(version, available):
@@ -299,6 +329,8 @@ def parse_args():
                    help="FOMOD version string (default: today's date, YYYY.MM.DD)")
     p.add_argument("--regenerate", action="store_true",
                    help="regenerate PDBs in the open Ghidra session first (via regenerate_pdbs.py/GhidrAssistMCP)")
+    p.add_argument("--force-regenerate", action="store_true",
+                   help="with --regenerate, regenerate even if Ghidra hasn't changed since the last regen")
     p.add_argument("--upload", action="store_true",
                    help="upload the built archive to Nexus as a new file version")
     p.add_argument("--nexus-file-id", default=NEXUS_FILE_ID,
@@ -314,6 +346,8 @@ def parse_args():
                    help="Nexus file description")
     p.add_argument("--archive-existing", action=argparse.BooleanOptionalAction, default=True,
                    help="move the file's current version to Old Files when uploading a new one (default: on)")
+    p.add_argument("--force-upload", action="store_true",
+                   help="upload even if the PDB content hash matches the last upload")
     p.add_argument("--changelog", default=None, help="changelog text to attach (requires --nexus-mod-id)")
     return p.parse_args()
 
@@ -331,7 +365,7 @@ def main():
     if args.regenerate:
         import regenerate_pdbs
         print(f"Regenerating {' '.join(args.runtimes)} via GhidrAssistMCP...\n")
-        regenerate_pdbs.regenerate_runtimes(args.runtimes)
+        regenerate_pdbs.regenerate_runtimes(args.runtimes, force=args.force_regenerate)
         print()
 
     sevenzip = find_7z(args.sevenzip)
@@ -354,14 +388,19 @@ def main():
 
     ok = [r for r in results if r[1]]
     bad = [r for r in results if not r[1]]
-    for key, success, msg, _ in results:
+    for key, success, msg, _, _ in results:
         print(f"  [{'OK ' if success else 'FAIL'}] {key}: {msg}")
 
     if not ok:
         print("\nno runtimes staged; nothing to package.")
         sys.exit(1)
 
-    available = [(key, RUNTIMES[key]) for key, success, _, _ in results if success]
+    available = [(key, RUNTIMES[key]) for key, success, _, _, _ in results if success]
+    # Hash the PDBs, not the final .7z -- verified empirically that repacking identical
+    # source PDBs produces a different archive hash each time (member order varies).
+    content_fingerprint = hashlib.sha256(
+        "\n".join(f"{key}:{sha}" for key, _, _, _, sha in sorted(ok, key=lambda r: r[0])).encode()
+    ).hexdigest()
     root = build_root(version, available)
     errors = root.validate()
     if errors:
@@ -392,12 +431,21 @@ def main():
     if args.upload:
         if bad:
             sys.exit("error: refusing to upload an archive missing runtimes -- fix the FAIL lines above first")
-        print(f"\nUploading to Nexus file {args.nexus_file_id} (mod {args.nexus_mod_id})...")
-        upload_to_nexus(archive, args.nexus_file_id, args.nexus_api_key, version,
-                         display_name=args.nexus_display_name, description=args.description,
-                         mod_id=args.nexus_mod_id, changelog=args.changelog,
-                         category=args.nexus_category, archive_existing=args.archive_existing)
-        print("Uploaded.")
+        state = load_state()
+        last = state.get("last_upload", {})
+        if not args.force_upload and last.get("content_fingerprint") == content_fingerprint:
+            print(f"\nPDB content unchanged since last upload (version {last.get('version')}); "
+                  "skipping. Pass --force-upload to upload anyway.")
+        else:
+            print(f"\nUploading to Nexus file {args.nexus_file_id} (mod {args.nexus_mod_id})...")
+            upload_to_nexus(archive, args.nexus_file_id, args.nexus_api_key, version,
+                             display_name=args.nexus_display_name, description=args.description,
+                             mod_id=args.nexus_mod_id, changelog=args.changelog,
+                             category=args.nexus_category, archive_existing=args.archive_existing)
+            print("Uploaded.")
+            state["last_upload"] = {"content_fingerprint": content_fingerprint, "version": version,
+                                     "uploaded_at": datetime.datetime.now().isoformat()}
+            save_state(state)
     else:
         print(f"\nUpload {archive} to the mod's files (version: {version}), "
               f"or re-run with --upload --nexus-file-id <id>.")

--- a/scripts/package_skyrim_pdbs.py
+++ b/scripts/package_skyrim_pdbs.py
@@ -57,8 +57,6 @@ import requests
 # Default 7-Zip location on Windows; override with --sevenzip.
 DEFAULT_7Z = r"C:\Program Files\7-Zip\7z.exe"
 
-# Shared pipeline state (per-runtime Ghidra modification numbers, last-uploaded content
-# fingerprint) -- lives under the already-gitignored pdb_artifacts/.
 STATE_FILE = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "pdb_artifacts", ".pdbgen_state.json")
 
 
@@ -187,7 +185,7 @@ def stage_runtime(key, cfg, stage_dir, require_fresh):
     asize = os.path.getsize(staged_pdb)
     return (key, True,
             f"{cfg['display_name']}  ({human_size(asize)})  "
-            f"<- {os.path.basename(src)} from {gen_date:%Y-%m-%d %H:%M}", gen_date, sha256_of(src))
+            f"<- {os.path.basename(src)} from {gen_date:%Y-%m-%d %H:%M}", gen_date, sha256_of(staged_pdb))
 
 
 def build_root(version, available):
@@ -310,11 +308,16 @@ def upload_to_nexus(archive_path, file_id, api_key, version, display_name, descr
     print(f"  created file version {version_id} on file {file_id}")
 
     if changelog and mod_id:
-        changelog_resp = session.post(f"{NEXUS_API_BASE}/mods/{mod_id}/changelogs",
-                                       json={"version": version, "changelog": changelog},
-                                       timeout=NEXUS_TIMEOUT)
-        changelog_resp.raise_for_status()
-        print("  changelog entry added")
+        # Non-fatal: the file version above already exists regardless -- a changelog
+        # failure must not skip recording the upload, or a retry duplicates the version.
+        try:
+            changelog_resp = session.post(f"{NEXUS_API_BASE}/mods/{mod_id}/changelogs",
+                                           json={"version": version, "changelog": changelog},
+                                           timeout=NEXUS_TIMEOUT)
+            changelog_resp.raise_for_status()
+            print("  changelog entry added")
+        except requests.exceptions.RequestException as e:
+            print(f"  WARNING: changelog entry failed (file version {version_id} still created): {e}")
 
     return version_id
 

--- a/scripts/package_skyrim_pdbs.py
+++ b/scripts/package_skyrim_pdbs.py
@@ -102,7 +102,8 @@ MOD_DESCRIPTION = (
     "Pick the variant matching your installed game version; the mod manager "
     "pre-selects it automatically where it can detect your game version."
 )
-MOD_WEBSITE = "https://www.nexusmods.com/skyrimspecialedition/mods/59818"
+NEXUS_MOD_ID = "59818"  # CrashLogger's mod page
+MOD_WEBSITE = f"https://www.nexusmods.com/skyrimspecialedition/mods/{NEXUS_MOD_ID}"
 STEP_PAGE_NAME = "Runtime PDB"
 STEP_GROUP_NAME = "Symbol file for your installed Skyrim version"
 
@@ -287,7 +288,7 @@ def parse_args():
                    help="Nexus file_id to add a version to (must already exist -- create it once via the website)")
     p.add_argument("--nexus-api-key", default=os.environ.get("NEXUS_API_KEY"),
                    help="Nexus API key (default: $NEXUS_API_KEY)")
-    p.add_argument("--nexus-mod-id", default="59818", help="Nexus mod_id, for --changelog")
+    p.add_argument("--nexus-mod-id", default=NEXUS_MOD_ID, help="Nexus mod_id, for --changelog")
     p.add_argument("--nexus-category", default="optional", help="Nexus file_category for the upload")
     p.add_argument("--changelog", default=None, help="changelog text to attach (requires --nexus-mod-id)")
     return p.parse_args()

--- a/scripts/package_skyrim_pdbs.py
+++ b/scripts/package_skyrim_pdbs.py
@@ -167,10 +167,10 @@ def build_root(version, available):
 
         option_type = pyfomod.Type()
         option_type.default = pyfomod.OptionType.OPTIONAL
-        # Each pattern is one gameDependency threshold; the mod manager evaluates them
-        # top-to-bottom, first match wins -- `available` must stay highest-game_version-first
-        # or the wrong option ends up Recommended.
-        for other_key, other_cfg in available:
+        # Patterns are evaluated top-to-bottom, first match wins. Iterate RUNTIMES, not
+        # `available` -- a missing runtime's threshold must still intercept, or a
+        # higher-version install falls through and gets recommended a mismatched PDB.
+        for other_key, other_cfg in RUNTIMES.items():
             conditions = pyfomod.Conditions()
             conditions[None] = other_cfg["game_version"]
             is_self = other_key == key

--- a/scripts/package_skyrim_pdbs.py
+++ b/scripts/package_skyrim_pdbs.py
@@ -237,6 +237,8 @@ def build_root(version, available):
 
 
 NEXUS_API_BASE = "https://api.nexusmods.com/v3"
+NEXUS_TIMEOUT = (10, 30)  # (connect, read) seconds -- metadata calls
+NEXUS_UPLOAD_TIMEOUT = (10, 300)  # part PUTs transfer real file bytes, need more time
 
 
 def upload_to_nexus(archive_path, file_id, api_key, version, display_name, description,
@@ -252,7 +254,7 @@ def upload_to_nexus(archive_path, file_id, api_key, version, display_name, descr
     filename = os.path.basename(archive_path)
 
     resp = session.post(f"{NEXUS_API_BASE}/uploads/multipart",
-                         json={"filename": filename, "size_bytes": str(size)})
+                         json={"filename": filename, "size_bytes": str(size)}, timeout=NEXUS_TIMEOUT)
     resp.raise_for_status()
     upload = resp.json()["data"]
     upload_id = upload["id"]
@@ -267,7 +269,8 @@ def upload_to_nexus(archive_path, file_id, api_key, version, display_name, descr
             chunk = f.read(part_size)
             part_resp = requests.put(part_url, data=chunk,
                                       headers={"Content-Type": "application/octet-stream",
-                                               "Content-Length": str(len(chunk))})
+                                               "Content-Length": str(len(chunk))},
+                                      timeout=NEXUS_UPLOAD_TIMEOUT)
             part_resp.raise_for_status()
             etag = part_resp.headers["ETag"].strip('"')
             parts.append((i, etag))
@@ -277,14 +280,15 @@ def upload_to_nexus(archive_path, file_id, api_key, version, display_name, descr
         f"  <Part>\n    <PartNumber>{n}</PartNumber>\n    <ETag>{tag}</ETag>\n  </Part>" for n, tag in parts
     ) + "\n</CompleteMultipartUpload>"
     complete_resp = requests.post(complete_url, data=complete_xml,
-                                   headers={"Content-Type": "application/xml"})
+                                   headers={"Content-Type": "application/xml"},
+                                   timeout=NEXUS_TIMEOUT)
     complete_resp.raise_for_status()
 
-    finalise_resp = session.post(f"{NEXUS_API_BASE}/uploads/{upload_id}/finalise")
+    finalise_resp = session.post(f"{NEXUS_API_BASE}/uploads/{upload_id}/finalise", timeout=NEXUS_TIMEOUT)
     finalise_resp.raise_for_status()
 
     for attempt in range(60):
-        state_resp = session.get(f"{NEXUS_API_BASE}/uploads/{upload_id}")
+        state_resp = session.get(f"{NEXUS_API_BASE}/uploads/{upload_id}", timeout=NEXUS_TIMEOUT)
         state_resp.raise_for_status()
         state = state_resp.json()["data"]["state"]
         if state == "available":
@@ -300,14 +304,15 @@ def upload_to_nexus(archive_path, file_id, api_key, version, display_name, descr
         "version": version,
         "file_category": category,
         "archive_existing_file": archive_existing,
-    })
+    }, timeout=NEXUS_TIMEOUT)
     version_resp.raise_for_status()
     version_id = version_resp.json()["data"]["version"]["id"]
     print(f"  created file version {version_id} on file {file_id}")
 
     if changelog and mod_id:
         changelog_resp = session.post(f"{NEXUS_API_BASE}/mods/{mod_id}/changelogs",
-                                       json={"version": version, "changelog": changelog})
+                                       json={"version": version, "changelog": changelog},
+                                       timeout=NEXUS_TIMEOUT)
         changelog_resp.raise_for_status()
         print("  changelog entry added")
 
@@ -365,7 +370,12 @@ def main():
     if args.regenerate:
         import regenerate_pdbs
         print(f"Regenerating {' '.join(args.runtimes)} via GhidrAssistMCP...\n")
-        regenerate_pdbs.regenerate_runtimes(args.runtimes, force=args.force_regenerate)
+        regen_results = regenerate_pdbs.regenerate_runtimes(args.runtimes, force=args.force_regenerate)
+        failed_regen = {key for key, ok, _ in regen_results if not ok}
+        if failed_regen:
+            print(f"\nRegeneration failed for {', '.join(sorted(failed_regen))} -- excluding from this "
+                  "run rather than packaging a possibly-stale existing PDB for them.")
+            args.runtimes = [k for k in args.runtimes if k not in failed_regen]
         print()
 
     sevenzip = find_7z(args.sevenzip)
@@ -431,6 +441,10 @@ def main():
     if args.upload:
         if bad:
             sys.exit("error: refusing to upload an archive missing runtimes -- fix the FAIL lines above first")
+        if set(args.runtimes) != set(RUNTIMES):
+            sys.exit(f"error: refusing to upload a partial archive ({', '.join(sorted(args.runtimes))} only) "
+                     "-- the uploaded file replaces the combined all-runtimes archive; "
+                     "run with all runtimes (default) to upload")
         state = load_state()
         last = state.get("last_upload", {})
         if not args.force_upload and last.get("content_fingerprint") == content_fingerprint:

--- a/scripts/package_skyrim_pdbs.py
+++ b/scripts/package_skyrim_pdbs.py
@@ -355,12 +355,12 @@ def main():
 
     pyfomod.write(root, stage_root)
 
-    archive_name = f"CrashLogger-PDBs-{version}.zip"
+    archive_name = f"CrashLogger-PDBs-{version}.7z"
     archive = os.path.join(args.out, archive_name)
     if os.path.isfile(archive):
         os.remove(archive)
     proc = subprocess.run(
-        [sevenzip, "a", "-tzip", "-mx=9", archive, "."],
+        [sevenzip, "a", "-t7z", "-mx=9", archive, "."],
         cwd=stage_root, capture_output=True, text=True)
     if proc.returncode != 0:
         print(f"error: 7z failed: {proc.stdout}\n{proc.stderr}", file=sys.stderr)

--- a/scripts/package_skyrim_pdbs.py
+++ b/scripts/package_skyrim_pdbs.py
@@ -31,7 +31,12 @@ run inside the open Ghidra session (PdbGen script per program), since it needs t
 analyzed project. This script packages whatever PDBs are currently on disk; pass
 --require-fresh <days> to refuse stale PDBs so you don't ship an outdated symbol set.
 
-Requires: pip install pyfomod
+Pass --upload --nexus-file-id <id> to push the built archive straight to Nexus as a new
+file version (Nexus's public v3 API, no CI involved) instead of uploading it by hand.
+The target file_id must already exist on the mod page -- Nexus's API can only add a
+version to an existing file entry, not create a new one; create it once via the website.
+
+Requires: pip install pyfomod requests
 """
 
 import argparse
@@ -40,8 +45,10 @@ import os
 import shutil
 import subprocess
 import sys
+import time
 
 import pyfomod
+import requests
 
 # Default 7-Zip location on Windows; override with --sevenzip.
 DEFAULT_7Z = r"C:\Program Files\7-Zip\7z.exe"
@@ -184,6 +191,83 @@ def build_root(version, available):
     return root
 
 
+NEXUS_API_BASE = "https://api.nexusmods.com/v3"
+
+
+def upload_to_nexus(archive_path, file_id, api_key, version, display_name,
+                     mod_id=None, changelog=None, category="optional",
+                     archive_existing=False):
+    """Push archive_path to Nexus as a new version of file_id via the public v3 API --
+    the same multipart-upload + finalise + create-version flow as Nexus-Mods/upload-action,
+    reimplemented directly so it runs on the Ghidra machine without a CI dependency."""
+    session = requests.Session()
+    session.headers.update({"apikey": api_key, "User-Agent": "package_skyrim_pdbs.py"})
+
+    size = os.path.getsize(archive_path)
+    filename = os.path.basename(archive_path)
+
+    resp = session.post(f"{NEXUS_API_BASE}/uploads/multipart",
+                         json={"filename": filename, "size_bytes": str(size)})
+    resp.raise_for_status()
+    upload = resp.json()["data"]
+    upload_id = upload["id"]
+    part_urls = upload["part_presigned_urls"]
+    part_size = upload["part_size_bytes"]
+    complete_url = upload["complete_presigned_url"]
+    print(f"  multipart upload {upload_id}: {len(part_urls)} part(s) x {human_size(part_size)}")
+
+    parts = []
+    with open(archive_path, "rb") as f:
+        for i, part_url in enumerate(part_urls, start=1):
+            chunk = f.read(part_size)
+            part_resp = requests.put(part_url, data=chunk,
+                                      headers={"Content-Type": "application/octet-stream",
+                                               "Content-Length": str(len(chunk))})
+            part_resp.raise_for_status()
+            etag = part_resp.headers["ETag"].strip('"')
+            parts.append((i, etag))
+            print(f"  uploaded part {i}/{len(part_urls)}")
+
+    complete_xml = "<CompleteMultipartUpload>\n" + "\n".join(
+        f"  <Part>\n    <PartNumber>{n}</PartNumber>\n    <ETag>{tag}</ETag>\n  </Part>" for n, tag in parts
+    ) + "\n</CompleteMultipartUpload>"
+    complete_resp = requests.post(complete_url, data=complete_xml,
+                                   headers={"Content-Type": "application/xml"})
+    complete_resp.raise_for_status()
+
+    finalise_resp = session.post(f"{NEXUS_API_BASE}/uploads/{upload_id}/finalise")
+    finalise_resp.raise_for_status()
+
+    for attempt in range(60):
+        state_resp = session.get(f"{NEXUS_API_BASE}/uploads/{upload_id}")
+        state_resp.raise_for_status()
+        state = state_resp.json()["data"]["state"]
+        if state == "available":
+            break
+        time.sleep(min(2 * 1.5 ** attempt, 30))
+    else:
+        raise TimeoutError(f"upload {upload_id} did not become available in time")
+
+    version_resp = session.post(f"{NEXUS_API_BASE}/mod-files/{file_id}/versions", json={
+        "upload_id": upload_id,
+        "name": display_name,
+        "version": version,
+        "file_category": category,
+        "archive_existing_file": archive_existing,
+    })
+    version_resp.raise_for_status()
+    version_id = version_resp.json()["data"]["version"]["id"]
+    print(f"  created file version {version_id} on file {file_id}")
+
+    if changelog and mod_id:
+        changelog_resp = session.post(f"{NEXUS_API_BASE}/mods/{mod_id}/changelogs",
+                                       json={"version": version, "changelog": changelog})
+        changelog_resp.raise_for_status()
+        print("  changelog entry added")
+
+    return version_id
+
+
 def parse_args():
     p = argparse.ArgumentParser(description=__doc__,
                                 formatter_class=argparse.RawDescriptionHelpFormatter)
@@ -197,11 +281,28 @@ def parse_args():
                    help="fail if any source PDB is older than DAYS (guards against shipping stale symbols)")
     p.add_argument("--version", default=None,
                    help="FOMOD version string (default: today's date, YYYY.MM.DD)")
+    p.add_argument("--upload", action="store_true",
+                   help="upload the built archive to Nexus as a new file version (requires --nexus-file-id)")
+    p.add_argument("--nexus-file-id", default=None,
+                   help="Nexus file_id to add a version to (must already exist -- create it once via the website)")
+    p.add_argument("--nexus-api-key", default=os.environ.get("NEXUS_API_KEY"),
+                   help="Nexus API key (default: $NEXUS_API_KEY)")
+    p.add_argument("--nexus-mod-id", default="59818", help="Nexus mod_id, for --changelog")
+    p.add_argument("--nexus-category", default="optional", help="Nexus file_category for the upload")
+    p.add_argument("--changelog", default=None, help="changelog text to attach (requires --nexus-mod-id)")
     return p.parse_args()
 
 
 def main():
     args = parse_args()
+    if args.upload:
+        if not args.nexus_file_id:
+            sys.exit("error: --upload requires --nexus-file-id")
+        if not args.nexus_api_key:
+            sys.exit("error: --upload requires --nexus-api-key or $NEXUS_API_KEY")
+        if args.changelog and not args.nexus_mod_id:
+            sys.exit("error: --changelog requires --nexus-mod-id")
+
     sevenzip = find_7z(args.sevenzip)
     args.out = os.path.abspath(args.out)
     version = args.version or datetime.date.today().strftime("%Y.%m.%d")
@@ -256,7 +357,19 @@ def main():
     if bad:
         print("Missing/stale runtimes were skipped (see FAIL lines above); "
               "regenerate them in Ghidra and re-run to include them.")
-    print(f"\nUpload {archive} to the mod's files (version: {version}).")
+
+    if args.upload:
+        if bad:
+            sys.exit("error: refusing to upload an archive missing runtimes -- fix the FAIL lines above first")
+        print(f"\nUploading to Nexus file {args.nexus_file_id} (mod {args.nexus_mod_id})...")
+        upload_to_nexus(archive, args.nexus_file_id, args.nexus_api_key, version,
+                         display_name=archive_name, mod_id=args.nexus_mod_id,
+                         changelog=args.changelog, category=args.nexus_category)
+        print("Uploaded.")
+    else:
+        print(f"\nUpload {archive} to the mod's files (version: {version}), "
+              f"or re-run with --upload --nexus-file-id <id>.")
+
     if bad:
         sys.exit(1)
 

--- a/scripts/package_skyrim_pdbs.py
+++ b/scripts/package_skyrim_pdbs.py
@@ -54,7 +54,7 @@ import requests
 DEFAULT_7Z = r"C:\Program Files\7-Zip\7z.exe"
 
 # Runtime table. Edit paths here if a game install moves.
-#   key            : short id used on the CLI (--runtimes se ae se17 vr)
+#   key            : short id used on the CLI (--runtimes se ae ae17 vr)
 #   src_pdb        : where Ghidra/pdbgen writes this runtime's PDB
 #   consumer_name  : filename DIA looks for inside Data/SKSE/Plugins/ (the exe's basename + .pdb)
 #   display_name   : shown in the FOMOD option list and used in the version string
@@ -64,7 +64,7 @@ DEFAULT_7Z = r"C:\Program Files\7-Zip\7z.exe"
 # stale prior deploys. "se" (1.5.97) has no distinct source file; verify the right build
 # is behind the plain SkyrimSE.exe import before packaging.
 RUNTIMES = {
-    "se17": {
+    "ae17": {
         "src_pdb": r"E:\SteamLibrary\steamapps\common\Skyrim Special Edition\SkyrimSE.1.7.99.pdb",
         "consumer_name": "SkyrimSE.pdb",
         "display_name": "SkyrimSE 1.7.99.0",

--- a/scripts/package_skyrim_pdbs.py
+++ b/scripts/package_skyrim_pdbs.py
@@ -14,15 +14,8 @@ hand, this builds ONE archive with a FOMOD installer: a single install step offe
 4 runtime PDBs as mutually-exclusive options, gameDependency-conditioned on the
 installed Skyrim version so the mod manager pre-selects the matching one automatically
 -- same mechanism as our sister repo open-shaders uses for its shader-cache picker
-(.github/scripts/build-fomod-package.py), and same reasoning: gameDependency has no
-comparison operator or negation, only "installed game version >= X", so each option's
-pattern list checks every runtime's threshold ordered highest-to-lowest game_version
-first so the first (most specific) match wins, rather than a lower threshold also
-matching and overriding it. RUNTIMES below must stay ordered highest game_version first
-for this to hold; a runtime on a wholly different game (VR) still composes correctly
-here since its threshold (1.4.15) is numerically lower than every SE/AE threshold, so an
-SE/AE install always intercepts before ever reaching VR's pattern, and a VR install
-(never >= 1.5.97) falls through to VR's own pattern.
+(.github/scripts/build-fomod-package.py). See build_root() for the threshold-ordering
+mechanics; RUNTIMES below must stay ordered highest game_version first.
 
 Per runtime:
   1. locate the freshest source PDB (Ghidra/pdbgen output),
@@ -59,16 +52,9 @@ DEFAULT_7Z = r"C:\Program Files\7-Zip\7z.exe"
 #   consumer_name  : filename DIA looks for inside Data/SKSE/Plugins/ (the exe's basename + .pdb)
 #   display_name   : shown in the FOMOD option list and used in the version string
 #   game_version   : gameDependency threshold -- MUST stay ordered highest-to-lowest below
-#                    (see module docstring for why)
-# IMPORTANT: PdbGen writes the .pdb next to each program's IMPORT path, which is the
-# game ROOT dir (where the .exe lives), NOT Data/SKSE/Plugins/. The Plugins copies are
-# the previously-deployed PDBs and go stale; always source from the root (PdbGen output).
-#
-# Each runtime is imported into Ghidra from its own distinctly-named exe copy so its
-# PdbGen output doesn't collide with another runtime's -- except 1.5.97, which is always
-# SkyrimSE.pdb (unsuffixed): that's the plain SkyrimSE.exe import. If the wrong build is
-# behind that path when this runs, that's a Ghidra-side problem to fix before packaging,
-# not something this script tries to detect -- it only checks whether the file exists.
+# Source from the game root (PdbGen's output dir), not Data/SKSE/Plugins/ -- those are
+# stale prior deploys. "se" (1.5.97) has no distinct source file; verify the right build
+# is behind the plain SkyrimSE.exe import before packaging.
 RUNTIMES = {
     "se17": {
         "src_pdb": r"E:\SteamLibrary\steamapps\common\Skyrim Special Edition\SkyrimSE.1.7.99.pdb",
@@ -181,11 +167,9 @@ def build_root(version, available):
 
         option_type = pyfomod.Type()
         option_type.default = pyfomod.OptionType.OPTIONAL
-        # All available runtimes, not just this one: each pattern is a single
-        # gameDependency threshold, evaluated top-to-bottom by the mod manager --
-        # first match wins. Listing them highest-game_version-first here (mirroring
-        # RUNTIMES' own order) means a higher runtime's threshold always intercepts
-        # before a lower one's, so only the actual best match ends up Recommended.
+        # Each pattern is one gameDependency threshold; the mod manager evaluates them
+        # top-to-bottom, first match wins -- `available` must stay highest-game_version-first
+        # or the wrong option ends up Recommended.
         for other_key, other_cfg in available:
             conditions = pyfomod.Conditions()
             conditions[None] = other_cfg["game_version"]

--- a/scripts/package_skyrim_pdbs.py
+++ b/scripts/package_skyrim_pdbs.py
@@ -59,6 +59,7 @@ DEFAULT_7Z = r"C:\Program Files\7-Zip\7z.exe"
 #   consumer_name  : filename DIA looks for inside Data/SKSE/Plugins/ (the exe's basename + .pdb)
 #   display_name   : shown in the FOMOD option list and used in the version string
 #   game_version   : gameDependency threshold -- MUST stay ordered highest-to-lowest below
+#   program_name   : Ghidra project path passed to scripts.run (regenerate_pdbs.py)
 # Source from the game root (PdbGen's output dir), not Data/SKSE/Plugins/ -- those are
 # stale prior deploys. "se" (1.5.97) has no distinct source file; verify the right build
 # is behind the plain SkyrimSE.exe import before packaging.
@@ -68,6 +69,7 @@ RUNTIMES = {
         "consumer_name": "SkyrimSE.pdb",
         "display_name": "SkyrimSE 1.7.99.0",
         "game_version": "1.7.99",
+        "program_name": "/SkyrimSE.1.7.99.exe",
     },
     "ae": {
         # AE imports from SkyrimSE.1170.exe -> PdbGen writes SkyrimSE.1170.pdb in the game root.
@@ -75,6 +77,7 @@ RUNTIMES = {
         "consumer_name": "SkyrimSE.pdb",  # same as SE: both runtimes execute SkyrimSE.exe; GUID disambiguates
         "display_name": "SkyrimSE 1.6.1170.0",
         "game_version": "1.6.1170",
+        "program_name": "/SkyrimSE.1170.exe",
     },
     "se": {
         # Always the unsuffixed SkyrimSE.pdb -- the plain SkyrimSE.exe import.
@@ -82,12 +85,14 @@ RUNTIMES = {
         "consumer_name": "SkyrimSE.pdb",
         "display_name": "SkyrimSE 1.5.97.0",
         "game_version": "1.5.97",
+        "program_name": "/SkyrimSE.exe",
     },
     "vr": {
         "src_pdb": r"E:\SteamLibrary\steamapps\common\SkyrimVR\SkyrimVR.pdb",
         "consumer_name": "SkyrimVR.pdb",
         "display_name": "SkyrimVR 1.4.15.0",
         "game_version": "1.4.15",
+        "program_name": "/SkyrimVR.exe",
     },
 }
 
@@ -282,6 +287,8 @@ def parse_args():
                    help="fail if any source PDB is older than DAYS (guards against shipping stale symbols)")
     p.add_argument("--version", default=None,
                    help="FOMOD version string (default: today's date, YYYY.MM.DD)")
+    p.add_argument("--regenerate", action="store_true",
+                   help="regenerate PDBs in the open Ghidra session first (via regenerate_pdbs.py/GhidrAssistMCP)")
     p.add_argument("--upload", action="store_true",
                    help="upload the built archive to Nexus as a new file version (requires --nexus-file-id)")
     p.add_argument("--nexus-file-id", default=None,
@@ -303,6 +310,12 @@ def main():
             sys.exit("error: --upload requires --nexus-api-key or $NEXUS_API_KEY")
         if args.changelog and not args.nexus_mod_id:
             sys.exit("error: --changelog requires --nexus-mod-id")
+
+    if args.regenerate:
+        import regenerate_pdbs
+        print(f"Regenerating {' '.join(args.runtimes)} via GhidrAssistMCP...\n")
+        regenerate_pdbs.regenerate_runtimes(args.runtimes)
+        print()
 
     sevenzip = find_7z(args.sevenzip)
     args.out = os.path.abspath(args.out)

--- a/scripts/regenerate_pdbs.py
+++ b/scripts/regenerate_pdbs.py
@@ -99,7 +99,10 @@ async def regenerate(runtime_keys, mcp_url, force):
             for key in runtime_keys:
                 cfg = RUNTIMES[key]
                 print(f"Regenerating {key} ({cfg['program_name']})...")
-                result = await regenerate_one(session, key, cfg, state, force)
+                try:
+                    result = await regenerate_one(session, key, cfg, state, force)
+                except Exception as e:
+                    result = (key, False, f"{cfg['program_name']}: MCP request failed: {e}")
                 results.append(result)
                 _, ok, msg = result
                 print(f"  [{'OK ' if ok else 'FAIL'}] {msg}")

--- a/scripts/regenerate_pdbs.py
+++ b/scripts/regenerate_pdbs.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""
+Trigger PdbGen.java in the already-open Ghidra session for each Skyrim runtime, via
+GhidrAssistMCP's local MCP server -- no Claude Code involved, just the MCP protocol
+directly. Requires Ghidra running with GhidrAssistMCP loaded and the runtime programs
+already open and analyzed (see RUNTIMES in package_skyrim_pdbs.py for program_name).
+
+This only regenerates; it does not stage/package/upload -- run package_skyrim_pdbs.py
+afterward (or use its --regenerate flag to chain both).
+
+Requires: pip install mcp
+"""
+
+import argparse
+import asyncio
+import os
+import re
+import sys
+
+from mcp import ClientSession
+from mcp.client.sse import sse_client
+
+from package_skyrim_pdbs import RUNTIMES
+
+DEFAULT_MCP_URL = os.environ.get("GHIDRA_MCP_URL", "http://localhost:8080/mcp")
+POLL_INTERVAL_SECONDS = 3
+SCRIPT_TIMEOUT_SECONDS = 300
+
+
+def text_of(result):
+    return "\n".join(getattr(block, "text", "") for block in result.content)
+
+
+async def regenerate_one(session, key, cfg):
+    program = cfg["program_name"]
+    run_result = await session.call_tool("scripts", {
+        "action": "run",
+        "name": "PdbGen.java",
+        "program_name": program,
+        "timeout_seconds": SCRIPT_TIMEOUT_SECONDS,
+    })
+    run_text = text_of(run_result)
+    match = re.search(r"task submitted:\s*([0-9a-fA-F-]+)", run_text)
+    if not match:
+        return (key, False, f"could not read task_id from: {run_text[:300]}")
+    task_id = match.group(1)
+
+    for _ in range(SCRIPT_TIMEOUT_SECONDS // POLL_INTERVAL_SECONDS):
+        await asyncio.sleep(POLL_INTERVAL_SECONDS)
+        status_result = await session.call_tool("get_task_status", {"task_id": task_id})
+        status_text = text_of(status_result)
+        if "Status: RUNNING" in status_text or "Status: PENDING" in status_text:
+            continue
+        if "exited with code" in status_text or "[PDBGEN] FAILED" in status_text:
+            return (key, False, f"{program}: pdbgen failed, see task {task_id}")
+        pdb_size = re.search(r"PDB file size:\s*(.+)", status_text)
+        if not pdb_size or "not found" in pdb_size.group(1):
+            return (key, False, f"{program}: no PDB produced, see task {task_id}")
+        return (key, True, f"{program}: {pdb_size.group(1).strip()}")
+
+    return (key, False, f"{program}: timed out after {SCRIPT_TIMEOUT_SECONDS}s (task {task_id})")
+
+
+async def regenerate(runtime_keys, mcp_url):
+    async with sse_client(mcp_url) as (read, write):
+        async with ClientSession(read, write) as session:
+            await session.initialize()
+            results = []
+            for key in runtime_keys:
+                cfg = RUNTIMES[key]
+                print(f"Regenerating {key} ({cfg['program_name']})...")
+                result = await regenerate_one(session, key, cfg)
+                results.append(result)
+                _, ok, msg = result
+                print(f"  [{'OK ' if ok else 'FAIL'}] {msg}")
+            return results
+
+
+def regenerate_runtimes(runtime_keys, mcp_url=DEFAULT_MCP_URL):
+    """Callable entry point for other scripts (e.g. package_skyrim_pdbs.py --regenerate).
+    Returns the (key, ok, message) results; does not exit the process."""
+    ordered_keys = [k for k in RUNTIMES if k in runtime_keys]
+    results = asyncio.run(regenerate(ordered_keys, mcp_url))
+    failed = [r for r in results if not r[1]]
+    print(f"\n{len(results) - len(failed)}/{len(results)} runtime(s) regenerated.")
+    return results
+
+
+def parse_args():
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--runtimes", nargs="+", default=list(RUNTIMES.keys()),
+                   choices=list(RUNTIMES.keys()),
+                   help="which runtimes to regenerate (default: all)")
+    p.add_argument("--mcp-url", default=DEFAULT_MCP_URL,
+                   help="GhidrAssistMCP endpoint (default: $GHIDRA_MCP_URL or http://localhost:8080/mcp)")
+    return p.parse_args()
+
+
+def main():
+    args = parse_args()
+    results = regenerate_runtimes(args.runtimes, args.mcp_url)
+    if any(not r[1] for r in results):
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/regenerate_pdbs.py
+++ b/scripts/regenerate_pdbs.py
@@ -5,6 +5,10 @@ GhidrAssistMCP's local MCP server -- no Claude Code involved, just the MCP proto
 directly. Requires Ghidra running with GhidrAssistMCP loaded and the runtime programs
 already open and analyzed (see RUNTIMES in package_skyrim_pdbs.py for program_name).
 
+Skips a runtime whose Program hasn't changed (Ghidra's own modification counter, which
+tracks every in-memory edit regardless of save state) since its last successful regen
+here, and whose source PDB still exists -- pass --force to regenerate anyway.
+
 This only regenerates; it does not stage/package/upload -- run package_skyrim_pdbs.py
 afterward (or use its --regenerate flag to chain both).
 
@@ -13,6 +17,7 @@ Requires: pip install mcp
 
 import argparse
 import asyncio
+import datetime
 import os
 import re
 import sys
@@ -20,7 +25,7 @@ import sys
 from mcp import ClientSession
 from mcp.client.sse import sse_client
 
-from package_skyrim_pdbs import RUNTIMES
+from package_skyrim_pdbs import RUNTIMES, load_state, save_state
 
 DEFAULT_MCP_URL = os.environ.get("GHIDRA_MCP_URL", "http://localhost:8080/mcp")
 POLL_INTERVAL_SECONDS = 3
@@ -31,8 +36,24 @@ def text_of(result):
     return "\n".join(getattr(block, "text", "") for block in result.content)
 
 
-async def regenerate_one(session, key, cfg):
+async def get_modification_number(session, program):
+    result = await session.call_tool("eval_python", {
+        "script": "print('MODNUM:' + str(currentProgram.getModificationNumber()))",
+        "program_name": program,
+        "sync": True,
+    })
+    match = re.search(r"MODNUM:(\d+)", text_of(result))
+    return int(match.group(1)) if match else None
+
+
+async def regenerate_one(session, key, cfg, state, force):
     program = cfg["program_name"]
+    modnum = await get_modification_number(session, program)
+    prior = state.get("runtimes", {}).get(key, {})
+    if (not force and modnum is not None and prior.get("modification_number") == modnum
+            and os.path.isfile(cfg["src_pdb"])):
+        return (key, True, f"{program}: unchanged since last regen (mod #{modnum}), skipped")
+
     run_result = await session.call_tool("scripts", {
         "action": "run",
         "name": "PdbGen.java",
@@ -56,12 +77,18 @@ async def regenerate_one(session, key, cfg):
         pdb_size = re.search(r"PDB file size:\s*(.+)", status_text)
         if not pdb_size or "not found" in pdb_size.group(1):
             return (key, False, f"{program}: no PDB produced, see task {task_id}")
+        state.setdefault("runtimes", {})[key] = {
+            "modification_number": modnum,
+            "regenerated_at": datetime.datetime.now().isoformat(),
+        }
+        save_state(state)
         return (key, True, f"{program}: {pdb_size.group(1).strip()}")
 
     return (key, False, f"{program}: timed out after {SCRIPT_TIMEOUT_SECONDS}s (task {task_id})")
 
 
-async def regenerate(runtime_keys, mcp_url):
+async def regenerate(runtime_keys, mcp_url, force):
+    state = load_state()
     async with sse_client(mcp_url) as (read, write):
         async with ClientSession(read, write) as session:
             await session.initialize()
@@ -69,18 +96,18 @@ async def regenerate(runtime_keys, mcp_url):
             for key in runtime_keys:
                 cfg = RUNTIMES[key]
                 print(f"Regenerating {key} ({cfg['program_name']})...")
-                result = await regenerate_one(session, key, cfg)
+                result = await regenerate_one(session, key, cfg, state, force)
                 results.append(result)
                 _, ok, msg = result
                 print(f"  [{'OK ' if ok else 'FAIL'}] {msg}")
             return results
 
 
-def regenerate_runtimes(runtime_keys, mcp_url=DEFAULT_MCP_URL):
+def regenerate_runtimes(runtime_keys, mcp_url=DEFAULT_MCP_URL, force=False):
     """Callable entry point for other scripts (e.g. package_skyrim_pdbs.py --regenerate).
     Returns the (key, ok, message) results; does not exit the process."""
     ordered_keys = [k for k in RUNTIMES if k in runtime_keys]
-    results = asyncio.run(regenerate(ordered_keys, mcp_url))
+    results = asyncio.run(regenerate(ordered_keys, mcp_url, force))
     failed = [r for r in results if not r[1]]
     print(f"\n{len(results) - len(failed)}/{len(results)} runtime(s) regenerated.")
     return results
@@ -94,12 +121,14 @@ def parse_args():
                    help="which runtimes to regenerate (default: all)")
     p.add_argument("--mcp-url", default=DEFAULT_MCP_URL,
                    help="GhidrAssistMCP endpoint (default: $GHIDRA_MCP_URL or http://localhost:8080/mcp)")
+    p.add_argument("--force", action="store_true",
+                   help="regenerate even if the Program hasn't changed since the last successful regen")
     return p.parse_args()
 
 
 def main():
     args = parse_args()
-    results = regenerate_runtimes(args.runtimes, args.mcp_url)
+    results = regenerate_runtimes(args.runtimes, args.mcp_url, args.force)
     if any(not r[1] for r in results):
         sys.exit(1)
 

--- a/scripts/regenerate_pdbs.py
+++ b/scripts/regenerate_pdbs.py
@@ -30,6 +30,9 @@ from package_skyrim_pdbs import RUNTIMES, load_state, save_state
 DEFAULT_MCP_URL = os.environ.get("GHIDRA_MCP_URL", "http://localhost:8080/mcp")
 POLL_INTERVAL_SECONDS = 3
 SCRIPT_TIMEOUT_SECONDS = 300
+# Bounds each individual MCP request -- SCRIPT_TIMEOUT_SECONDS only bounds our own polling
+# loop, not a single hung call, which would otherwise block the run indefinitely.
+MCP_READ_TIMEOUT_SECONDS = 60
 
 
 def text_of(result):
@@ -90,7 +93,7 @@ async def regenerate_one(session, key, cfg, state, force):
 async def regenerate(runtime_keys, mcp_url, force):
     state = load_state()
     async with sse_client(mcp_url) as (read, write):
-        async with ClientSession(read, write) as session:
+        async with ClientSession(read, write, read_timeout_seconds=MCP_READ_TIMEOUT_SECONDS) as session:
             await session.initialize()
             results = []
             for key in runtime_keys:


### PR DESCRIPTION
## Summary
- Replaces the previous 4-separate-`.7z` PDB packaging with one FOMOD-wrapped zip, so a mod manager (MO2/Vortex) can auto-select the correct runtime PDB by installed game version instead of the player picking one by hand -- same `gameDependency` threshold-interception pattern our sister repo open-shaders uses for its shader-cache picker (`.github/scripts/build-fomod-package.py`).
- Adds a 4th runtime: SE 1.7.99.
- Fixes the `se` (1.5.97) entry, which had silently drifted to 1.7.99 content after Steam auto-updated the live `SkyrimSE.pdb` out from under it -- caught mid-session while investigating why a packaged "1.5.97" archive didn't match its filename.
- All 4 runtime PDBs are named as the bare exe basename (`SkyrimSE.pdb`/`SkyrimVR.pdb`) inside the archive and install to `Data/SKSE/Plugins/`, matching what `PdbHandler.cpp`'s `loadDataForExe` looks for -- verified by extracting the built zip and checking both the staged file names and the generated `ModuleConfig.xml`'s `<folder>` destinations.

Depends on the companion `pdbgen` PRs (alandtse/pdbgen#2, #3) for generating the SE 1.7.99 PDB via the redesigned pipeline; this script itself just packages whatever PDBs already exist on disk.

## Test plan
- [x] Ran the script locally against all 4 real source PDBs freshly generated via the redesigned pdbgen pipeline; verified 4/4 packaged into one zip
- [x] Extracted the built zip and confirmed file names (`SkyrimSE.pdb`/`SkyrimVR.pdb`, no version suffix) and `ModuleConfig.xml` `<folder destination="SKSE/Plugins">` mappings
- [x] Ran with one source PDB deliberately missing; confirmed it's skipped with a clear `[FAIL]` line and the other 3 still package

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0127TrzQ98FRHh8cLU7WxNCK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Skyrim runtime PDBs are distributed in a 7z archive with a FOMOD installer.
  - Added automated PDB regeneration for selected or all supported runtimes.
  - Regeneration now skips unchanged runtimes, with an option to force regeneration.
  - Added configurable Nexus display name, description, file ID, and archive replacement options.
  - Added support for Anniversary Edition, Special Edition, and VR runtimes.
  - Installer options reflect the selected game version.
  - Custom FOMOD versions can be specified; otherwise, the current date is used.
- **Bug Fixes**
  - Prevented redundant uploads and excluded failed or incomplete runtime packages.
  - Improved validation for missing, outdated, invalid, or incomplete packages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->